### PR TITLE
fix: restore EVA providers in Nextcloud Assistant

### DIFF
--- a/lib/TaskProcessing/EvaChangeToneProvider.php
+++ b/lib/TaskProcessing/EvaChangeToneProvider.php
@@ -6,9 +6,8 @@ namespace OCA\EvaAi\TaskProcessing;
 
 use OCA\EvaAi\Service\Ollama;
 use OCP\IL10N;
-use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
-use OCP\TaskProcessing\ShapeDescriptor;
+use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\TaskTypes\TextToTextChangeTone;
 use RuntimeException;
 
@@ -37,42 +36,36 @@ class EvaChangeToneProvider implements ISynchronousProvider {
 	}
 
 	public function getInputShapeEnumValues(): array {
-		return [];
-	}
-
-	public function getInputShapeDefaults(): array {
-		return [];
-	}
-
-	public function getOptionalInputShape(): array {
-		return [
-			'tone' => new ShapeDescriptor(
-				$this->l->t('Tone'),
-				$this->l->t('The desired tone for the text.'),
-				EShapeType::Enum
-			),
-		];
-	}
-
-	public function getOptionalInputShapeEnumValues(): array {
 		return [
 			'tone' => [
-				'formal' => 'Formell',
-				'informal' => 'Informell',
-				'friendly' => 'Freundlich',
-				'professional' => 'Professionell',
-				'humorous' => 'Humorvoll',
-				'persuasive' => 'Überzeugend',
-				'concise' => 'Knapp',
-				'detailed' => 'Detailliert',
+				new ShapeEnumValue($this->l->t('Formal'), 'formal'),
+				new ShapeEnumValue($this->l->t('Informal'), 'informal'),
+				new ShapeEnumValue($this->l->t('Friendly'), 'friendly'),
+				new ShapeEnumValue($this->l->t('Professional'), 'professional'),
+				new ShapeEnumValue($this->l->t('Humorous'), 'humorous'),
+				new ShapeEnumValue($this->l->t('Persuasive'), 'persuasive'),
+				new ShapeEnumValue($this->l->t('Concise'), 'concise'),
+				new ShapeEnumValue($this->l->t('Detailed'), 'detailed'),
 			],
 		];
 	}
 
-	public function getOptionalInputShapeDefaults(): array {
+	public function getInputShapeDefaults(): array {
 		return [
 			'tone' => 'formal',
 		];
+	}
+
+	public function getOptionalInputShape(): array {
+		return [];
+	}
+
+	public function getOptionalInputShapeEnumValues(): array {
+		return [];
+	}
+
+	public function getOptionalInputShapeDefaults(): array {
+		return [];
 	}
 
 	public function getOutputShapeEnumValues(): array {

--- a/lib/TaskProcessing/EvaContextWriteProvider.php
+++ b/lib/TaskProcessing/EvaContextWriteProvider.php
@@ -84,12 +84,14 @@ class EvaContextWriteProvider implements ISynchronousProvider {
 			throw new RuntimeException('Kein Benutzerkontext');
 		}
 
-		$prompt = trim((string)($input['input'] ?? ''));
+		// ContextWrite's core task type uses source_input/style_input. Keep the
+		// older aliases as fallbacks for already queued tasks.
+		$prompt = trim((string)($input['source_input'] ?? $input['input'] ?? ''));
 		if ($prompt === '') {
 			throw new RuntimeException('Leere Eingabe');
 		}
 
-		$style = trim((string)($input['style'] ?? ''));
+		$style = trim((string)($input['style_input'] ?? $input['style'] ?? ''));
 		$example = trim((string)($input['example'] ?? ''));
 
 		$reportProgress(0.1);

--- a/lib/TaskProcessing/EvaTranslateProvider.php
+++ b/lib/TaskProcessing/EvaTranslateProvider.php
@@ -6,9 +6,8 @@ namespace OCA\EvaAi\TaskProcessing;
 
 use OCA\EvaAi\Service\Ollama;
 use OCP\IL10N;
-use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\ISynchronousProvider;
-use OCP\TaskProcessing\ShapeDescriptor;
+use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\TaskTypes\TextToTextTranslate;
 use RuntimeException;
 
@@ -37,70 +36,51 @@ class EvaTranslateProvider implements ISynchronousProvider {
 	}
 
 	public function getInputShapeEnumValues(): array {
-		return [];
+		$languages = [
+			'de' => 'Deutsch',
+			'en' => 'English',
+			'fr' => 'Français',
+			'es' => 'Español',
+			'it' => 'Italiano',
+			'nl' => 'Nederlands',
+			'pt' => 'Português',
+			'ru' => 'Русский',
+			'zh' => '中文',
+			'ja' => '日本語',
+			'ko' => '한국어',
+			'ar' => 'العربية',
+			'pl' => 'Polski',
+			'tr' => 'Türkçe',
+		];
+		$values = [];
+		foreach ($languages as $code => $name) {
+			$values[] = new ShapeEnumValue($name, $code);
+		}
+
+		return [
+			'origin_language' => array_merge([
+				new ShapeEnumValue($this->l->t('Detect language'), 'detect_language'),
+			], $values),
+			'target_language' => $values,
+		];
 	}
 
 	public function getInputShapeDefaults(): array {
-		return [];
+		return [
+			'origin_language' => 'detect_language',
+		];
 	}
 
 	public function getOptionalInputShape(): array {
-		return [
-			'origin_language' => new ShapeDescriptor(
-				$this->l->t('Source language'),
-				$this->l->t('The language of the text to translate.'),
-				EShapeType::Enum
-			),
-			'target_language' => new ShapeDescriptor(
-				$this->l->t('Target language'),
-				$this->l->t('The language to translate to.'),
-				EShapeType::Enum
-			),
-		];
+		return [];
 	}
 
 	public function getOptionalInputShapeEnumValues(): array {
-		return [
-			'origin_language' => [
-				'de' => 'Deutsch',
-				'en' => 'English',
-				'fr' => 'Français',
-				'es' => 'Español',
-				'it' => 'Italiano',
-				'nl' => 'Nederlands',
-				'pt' => 'Português',
-				'ru' => 'Русский',
-				'zh' => '中文',
-				'ja' => '日本語',
-				'ko' => '한국어',
-				'ar' => 'العربية',
-				'pl' => 'Polski',
-				'tr' => 'Türkçe',
-			],
-			'target_language' => [
-				'de' => 'Deutsch',
-				'en' => 'English',
-				'fr' => 'Français',
-				'es' => 'Español',
-				'it' => 'Italiano',
-				'nl' => 'Nederlands',
-				'pt' => 'Português',
-				'ru' => 'Русский',
-				'zh' => '中文',
-				'ja' => '日本語',
-				'ko' => '한국어',
-				'ar' => 'العربية',
-				'pl' => 'Polski',
-				'tr' => 'Türkçe',
-			],
-		];
+		return [];
 	}
 
 	public function getOptionalInputShapeDefaults(): array {
-		return [
-			'origin_language' => 'auto',
-			'target_language' => 'en',
-		];
+		return [];
 	}
 
 	public function getOutputShapeEnumValues(): array {
@@ -125,7 +105,7 @@ class EvaTranslateProvider implements ISynchronousProvider {
 			throw new RuntimeException('Leere Eingabe');
 		}
 
-		$originLanguage = (string)($input['origin_language'] ?? 'auto');
+		$originLanguage = (string)($input['origin_language'] ?? 'detect_language');
 		$targetLanguage = (string)($input['target_language'] ?? 'en');
 
 		$reportProgress(0.1);
@@ -154,7 +134,7 @@ class EvaTranslateProvider implements ISynchronousProvider {
 			. 'Gib nur die Übersetzung zurück, keine zusätzlichen Erklärungen oder Kommentare. '
 			. 'Behalte den ursprünglichen Ton und Stil bei.';
 
-		if ($originLanguage !== 'auto') {
+		if ($originLanguage !== 'auto' && $originLanguage !== 'detect_language') {
 			$originLangName = $languageMap[$originLanguage] ?? $originLanguage;
 			$systemPrompt = 'Du bist ein professioneller Übersetzer. '
 				. 'Übersetze den Text von ' . $originLangName . ' ins ' . $targetLangName . '. '


### PR DESCRIPTION
## What changed

- move EVA translation and tone enum metadata to the mandatory task input shapes expected by Nextcloud 34
- return `ShapeEnumValue` objects so the Assistant API serializes enum options as `{name, value}`
- keep automatic language detection compatible with Nextcloud's `detect_language` value
- accept the core `source_input` and `style_input` fields in the ContextWrite provider while retaining legacy fallbacks

## Why

The translation provider exposed mandatory language inputs as optional metadata. The Assistant frontend then tried to read a missing `inputShapeEnumValues.origin_language` entry, threw an exception, and discarded the complete task-type list. Users consequently saw "No provider found" even though EVA providers were registered.

## Impact

Nextcloud Assistant can load all EVA-backed task types again. Translation, tone changes, and ContextWrite now use the input contracts defined by Nextcloud 34.

## Validation

- PHP syntax checks for all three modified providers
- Assistant frontend-data validation for all 17 exposed task types and enum values
- preferred-provider mapping validation for all EVA task types
- live Ollama text generation returned `EVA_OK`
- live EVA translation returned `Good morning` for `Guten Morgen`
