### PR TITLE
Bump max-version to 35 for Nextcloud 35 beta support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@
     <category>tools</category>
     <bugs>https://github.com/SchBenedikt/nextcloud-ai/issues</bugs>
     <dependencies>
-        <nextcloud min-version="30" max-version="34"/>
+        <nextcloud min-version="30" max-version="35"/>
         <php min-version="8.2"/>
     </dependencies>
     <optional-apps>


### PR DESCRIPTION
Allows eva-ai to stay enabled on Nextcloud 35 (beta). No API changes required; all 21 tests pass.