### PR TITLE
Fix hard dependency on optional Talk app

### DIFF
--- a/lib/Command/TalkSetup.php
+++ b/lib/Command/TalkSetup.php
@@ -25,7 +25,6 @@ class TalkSetup extends Command {
 	public const BOT_URL = TalkBotRegistrar::BOT_URL;
 
     public function __construct(
-        private BotServerMapper $botServerMapper,
         private IAppManager $appManager,
         private ISecureRandom $random,
     ) {
@@ -45,13 +44,16 @@ class TalkSetup extends Command {
             $output->writeln('<error>Nextcloud Talk (spreed) is not installed or not enabled.</error>');
             return 1;
         }
+        // Talk is optional; resolve the mapper lazily so that occ can load this
+        // command even when Talk is not installed or enabled.
+        $botServerMapper = \OCP\Server::get(BotServerMapper::class);
         if ($input->getOption('remove')) {
-            return $this->remove($output);
+            return $this->remove($output, $botServerMapper);
         }
         $name = (string)$input->getOption('name');
         $description = (string)$input->getOption('description');
         try {
-            $existing = $this->botServerMapper->findByUrl(self::BOT_URL);
+            $existing = $botServerMapper->findByUrl(self::BOT_URL);
         } catch (\OCP\AppFramework\Db\DoesNotExistException) {
             $existing = null;
         } catch (DbException) {
@@ -73,7 +75,7 @@ class TalkSetup extends Command {
             $existing->setErrorCount(0);
             $existing->setLastErrorMessage('');
             try {
-                $bot = $this->botServerMapper->update($existing);
+                $bot = $botServerMapper->update($existing);
             } catch (DbException $e) {
                 $output->writeln('<error>Could not update bot: ' . $e->getMessage() . '</error>');
                 return 1;
@@ -91,7 +93,7 @@ class TalkSetup extends Command {
                 $bot->setDescription($description);
             }
             try {
-                $bot = $this->botServerMapper->insert($bot);
+                $bot = $botServerMapper->insert($bot);
             } catch (DbException $e) {
                 $output->writeln('<error>Could not insert bot: ' . $e->getMessage() . '</error>');
                 return 1;
@@ -107,15 +109,15 @@ class TalkSetup extends Command {
         return 0;
     }
 
-    private function remove(OutputInterface $output): int {
+    private function remove(OutputInterface $output, BotServerMapper $botServerMapper): int {
         try {
-            $existing = $this->botServerMapper->findByUrl(self::BOT_URL);
+            $existing = $botServerMapper->findByUrl(self::BOT_URL);
         } catch (\OCP\AppFramework\Db\DoesNotExistException) {
             $output->writeln('No Eva-AI Talk bot registered.');
             return 0;
         }
         try {
-            $this->botServerMapper->delete($existing);
+            $botServerMapper->delete($existing);
             $output->writeln('<info>Removed Eva-AI Talk bot.</info>');
         } catch (DbException $e) {
             $output->writeln('<error>Could not remove bot: ' . $e->getMessage() . '</error>');

--- a/lib/Service/TalkBotRegistrar.php
+++ b/lib/Service/TalkBotRegistrar.php
@@ -23,7 +23,6 @@ class TalkBotRegistrar {
 	public const BOT_URL = 'nextcloudapp://eva-ai/bot';
 
 	public function __construct(
-		private BotServerMapper $botServerMapper,
 		private IAppManager $appManager,
 		private ISecureRandom $random,
 		private LoggerInterface $logger,
@@ -39,8 +38,11 @@ class TalkBotRegistrar {
 		if (!$this->appManager->isEnabledForAnyone('spreed')) {
 			return;
 		}
+		// Talk is optional; resolve the mapper lazily so that the app can boot
+		// even when Talk is not installed or enabled.
+		$botServerMapper = \OCP\Server::get(BotServerMapper::class);
 		try {
-			$this->botServerMapper->findByUrl(self::BOT_URL);
+			$botServerMapper->findByUrl(self::BOT_URL);
 			return; // bereits registriert
 		} catch (DoesNotExistException) {
 			// neu anlegen
@@ -61,7 +63,7 @@ class TalkBotRegistrar {
 		$bot->setFeatures(Bot::FEATURE_RESPONSE | Bot::FEATURE_EVENT);
 		$bot->setDescription('Eva AI assistant: chat with your indexed files.');
 		try {
-			$this->botServerMapper->insert($bot);
+			$botServerMapper->insert($bot);
 		} catch (DbException $e) {
 			$this->logger->warning('eva-ai: could not auto-register Talk bot: ' . $e->getMessage(), [
 				'exception' => $e,


### PR DESCRIPTION
TalkSetup command and TalkBotRegistrar injected OCA\\Talk classes via constructor, breaking every occ command whenever Talk (spreed) is not enabled (e.g. after a Nextcloud major upgrade). The mapper is now resolved lazily at runtime after checking that Talk is enabled.