### PR TITLE
fix: resolve chat persistence and README issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,94 +221,6 @@ The chat interprets times in the user's timezone (e.g. `Europe/Berlin`):
 - A plain date → all-day event
 - Reminders via the `reminder_minutes` parameter (e.g. 30, 60)
 
-<<<<<<< HEAD
-## Data Lifecycle & Privacy
-
-EVA operates on your personal Nextcloud data. This section documents what data is stored,
-how long it is retained, and how to remove it.
-
-### What data does EVA store?
-
-| Data Type | Storage Location | Retention |
-|---|---|---|
-| Indexed document metadata (file path, name, hash, MIME type, size) | Nextcloud database (`eva_ai_documents`) | Until the file is deleted from Nextcloud or index is reset |
-| Text chunks (split from indexed files) | Nextcloud database (`eva_ai_chunks`) | Same as parent document |
-| Embedding vectors (numerical representations of chunks) | Nextcloud database (`eva_ai_chunks`) | Same as parent document |
-| Indexed email metadata (subject, sender, body excerpt) | Nextcloud database (`eva_ai_documents`) | Until the email changes or index is reset |
-| Email chunks and embeddings | Nextcloud database (`eva_ai_chunks`) | Same as parent email document |
-| Chat history (conversation messages) | Nextcloud database (`eva_ai_chat_history`) | Stored per user; deleted on index reset |
-| AI-created file markers (tracking which files EVA created) | Nextcloud app-data (`ai-marks/`) | Until the file is deleted or manually cleaned |
-| Knowledge base entries (KNOWLEDGE.md) | User's Nextcloud home folder | Until the user deletes the file |
-| Agent conversation state | Nextcloud database (`eva_ai_agent_store`) | Per conversation token; deleted on reset |
-| App configuration | Nextcloud database (`oc_appconfig`) | Persistent until manually changed |
-
-### Where is data processed?
-
-- **All processing is local**: file indexing, text extraction, chunking, embedding generation,
-  and LLM chat all happen on your own server.
-- **Ollama** is the only external component — it runs locally on your machine.
-  No file contents, emails, or personal data are ever sent to third-party services.
-- **Weather queries** use the free Open-Meteo API (no API key, no user data sent).
-
-### What happens when a file is modified or deleted?
-
-- **File modified**: The next indexing pass detects the content hash change,
-  re-chunks the file, generates new embeddings, and replaces the old index entry.
-- **File deleted from Nextcloud**: The next indexing pass detects the missing file ID
-  and automatically removes the document and all its chunks from the index.
-- **File becomes unreadable/non-indexable**: Stale index entries are removed during
-  reconciliation (the file ID appears in the filesystem but extraction fails).
-- **Shared file access revoked**: EVA only indexes files the user can currently read.
-  Revoked shares are not indexed; previously indexed content from revoked shares
-  is removed during the next indexing pass.
-- **Email deleted**: The next email indexing pass skips deleted emails. Old indexed
-  email content is removed when the email entry is no longer found.
-
-### How to delete all EVA data
-
-**Reset a single user's index:**
-
-```bash
-sudo -u www-data php occ eva-ai:reset --user=username
-```
-
-This removes all documents, chunks, chat history, agent state, and AI-created file
-markers for the specified user.
-
-**Reset ALL users:**
-
-```bash
-sudo -u www-data php occ eva-ai:reset --all
-```
-
-**Remove the AI-created file markers only:**
-
-```bash
-sudo -u www-data php occ eva-ai:reset --user=username --marks-only
-```
-
-**Uninstall the app completely:**
-
-```bash
-sudo -u www-data php occ app:remove eva-ai
-```
-
-This drops all database tables and removes the app-data folder.
-
-### Configuration defaults affecting privacy
-
-| Setting | Default | Privacy Impact |
-|---|---|---|
-| `mail_index_enabled` | `1` (on) | Emails are indexed into RAG. Set to `0` to disable. |
-| `actions_enabled` | `1` (on) | The AI can create/rename/delete files. Set to `0` for read-only chat. |
-| `exec_delete_mode` | `own` | Only files EVA created itself can be deleted. Set to `off` to disable deletion entirely. |
-| `exec_write_types` | `''` (all) | Restrict which file types EVA can create (e.g. `md,txt`). |
-| `index_user` | `''` (current user) | Only this user's files are indexed. Leave empty for per-user indexing. |
-
-## Notes
-=======
----
->>>>>>> 8f973d3 (WIP: fix issues #5-#16 + app-id rename to eva_ai)
 
 ## Data lifecycle & privacy
 
@@ -322,7 +234,7 @@ Quick reference:
 | Document metadata | DB (`eva_ai_documents`) | Until file deleted or index reset |
 | Text chunks & embeddings | DB (`eva_ai_chunks`) | Same as parent document |
 | Indexed emails | DB (`eva_ai_documents`) | Until email changes or index reset |
-| Chat history | DB (`eva_ai_chat_history`) | Per user; deleted on index reset |
+| Chat history | AppData (`eva_ai/chats/<user namespace>/chats.json`) | Until the user deletes chats or app data is removed |
 | AI-created file markers | app-data (`ai-marks/`) | Until file deleted or cleaned |
 | Knowledge base (`KNOWLEDGE.md`) | User home | Until user deletes the file |
 | Agent conversation state | DB (`eva_ai_agent_store`) | Per conversation token; deleted on reset |

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -370,8 +370,12 @@ class ApiController extends OCSController {
         if ($user === null) {
             return new DataResponse(['error' => 'Not logged in'], 401);
         }
-        $chat = $this->chatStore->create($user, (string)($this->request->getParam('title') ?? ''));
-        return new DataResponse($chat);
+        try {
+            $chat = $this->chatStore->create($user, (string)($this->request->getParam('title') ?? ''));
+            return new DataResponse($chat);
+        } catch (\Throwable $e) {
+            return new DataResponse(['error' => 'Unable to persist chat data'], 500);
+        }
     }
 
     #[NoAdminRequired]
@@ -393,10 +397,14 @@ class ApiController extends OCSController {
         if ($user === null) {
             return new DataResponse(['error' => 'Not logged in'], 401);
         }
-        if (!$this->chatStore->delete($user, $id)) {
-            return new NotFoundResponse();
+        try {
+            if (!$this->chatStore->delete($user, $id)) {
+                return new NotFoundResponse();
+            }
+            return new DataResponse(['ok' => true]);
+        } catch (\Throwable $e) {
+            return new DataResponse(['error' => 'Unable to persist chat data'], 500);
         }
-        return new DataResponse(['ok' => true]);
     }
 
     #[NoAdminRequired]
@@ -405,16 +413,20 @@ class ApiController extends OCSController {
         if ($user === null) {
             return new DataResponse(['error' => 'Not logged in'], 401);
         }
-        if ($this->chatStore->get($user, $id) === null) {
-            return new NotFoundResponse();
+        try {
+            if ($this->chatStore->get($user, $id) === null) {
+                return new NotFoundResponse();
+            }
+            $role = (string)($this->request->getParam('role') ?? '');
+            $text = trim((string)($this->request->getParam('text') ?? ''));
+            if ($role === '' || $text === '') {
+                return new DataResponse(['error' => 'role and text are required'], 400);
+            }
+            $this->chatStore->append($user, $id, $role, $text);
+            return new DataResponse(['ok' => true]);
+        } catch (\Throwable $e) {
+            return new DataResponse(['error' => 'Unable to persist chat data'], 500);
         }
-        $role = (string)($this->request->getParam('role') ?? '');
-        $text = trim((string)($this->request->getParam('text') ?? ''));
-        if ($role === '' || $text === '') {
-            return new DataResponse(['error' => 'role and text are required'], 400);
-        }
-        $this->chatStore->append($user, $id, $role, $text);
-        return new DataResponse(['ok' => true]);
     }
 
     #[NoAdminRequired]
@@ -423,15 +435,19 @@ class ApiController extends OCSController {
         if ($user === null) {
             return new DataResponse(['error' => 'Not logged in'], 401);
         }
-        if ($this->chatStore->get($user, $id) === null) {
-            return new NotFoundResponse();
+        try {
+            if ($this->chatStore->get($user, $id) === null) {
+                return new NotFoundResponse();
+            }
+            $title = trim((string)($this->request->getParam('title') ?? ''));
+            if ($title === '') {
+                return new DataResponse(['error' => 'title required'], 400);
+            }
+            $this->chatStore->setTitle($user, $id, $title);
+            return new DataResponse(['ok' => true]);
+        } catch (\Throwable $e) {
+            return new DataResponse(['error' => 'Unable to persist chat data'], 500);
         }
-        $title = trim((string)($this->request->getParam('title') ?? ''));
-        if ($title === '') {
-            return new DataResponse(['error' => 'title required'], 400);
-        }
-        $this->chatStore->setTitle($user, $id, $title);
-        return new DataResponse(['ok' => true]);
     }
 
     #[NoAdminRequired]

--- a/lib/Service/ChatStore.php
+++ b/lib/Service/ChatStore.php
@@ -31,95 +31,107 @@ class ChatStore {
 
     /** @return list<array{id:string,title:string,created:int,updated:int,count:int}> */
     public function list(string $user): array {
-        $all = $this->read($user);
-        $out = [];
-        foreach ($all as $chat) {
-            $out[] = [
-                'id' => $chat['id'] ?? '',
-                'title' => $chat['title'] ?? 'Neuer Chat',
-                'created' => $chat['created'] ?? 0,
-                'updated' => $chat['updated'] ?? 0,
-                'count' => count($chat['messages'] ?? []),
-            ];
-        }
-        usort($out, static fn($a, $b) => $b['updated'] <=> $a['updated']);
-        return $out;
+        return $this->withUserLock($user, function () use ($user): array {
+            $all = $this->read($user);
+            $out = [];
+            foreach ($all as $chat) {
+                $out[] = [
+                    'id' => $chat['id'] ?? '',
+                    'title' => $chat['title'] ?? 'Neuer Chat',
+                    'created' => $chat['created'] ?? 0,
+                    'updated' => $chat['updated'] ?? 0,
+                    'count' => count($chat['messages'] ?? []),
+                ];
+            }
+            usort($out, static fn($a, $b) => $b['updated'] <=> $a['updated']);
+            return $out;
+        });
     }
 
     /** @return array|null */
     public function get(string $user, string $id): ?array {
-        foreach ($this->read($user) as $chat) {
-            if (($chat['id'] ?? '') === $id) {
-                return $chat;
+        return $this->withUserLock($user, function () use ($user, $id): ?array {
+            foreach ($this->read($user) as $chat) {
+                if (($chat['id'] ?? '') === $id) {
+                    return $chat;
+                }
             }
-        }
-        return null;
+            return null;
+        });
     }
 
     public function create(string $user, ?string $title = null): array {
-        // Keine doppelten leeren Chats: ein noch leerer Chat wird wiederverwendet.
-        $all = $this->read($user);
-        foreach ($all as $existing) {
-            if (count($existing['messages'] ?? []) === 0) {
-                $existing['reused'] = true;
-                return $existing;
+        return $this->withUserLock($user, function () use ($user, $title): array {
+            // Keine doppelten leeren Chats: ein noch leerer Chat wird wiederverwendet.
+            $all = $this->read($user);
+            foreach ($all as $existing) {
+                if (count($existing['messages'] ?? []) === 0) {
+                    $existing['reused'] = true;
+                    return $existing;
+                }
             }
-        }
-        $chat = [
-            'id' => 'c' . date('YmdHis') . '-' . bin2hex(random_bytes(4)),
-            'title' => $title !== null && $title !== '' ? $this->clipTitle($title) : 'Neuer Chat',
-            'created' => time(),
-            'updated' => time(),
-            'messages' => [],
-        ];
-        $all[] = $chat;
-        $this->write($user, $all);
-        return $chat;
+            $chat = [
+                'id' => 'c' . date('YmdHis') . '-' . bin2hex(random_bytes(4)),
+                'title' => $title !== null && $title !== '' ? $this->clipTitle($title) : 'Neuer Chat',
+                'created' => time(),
+                'updated' => time(),
+                'messages' => [],
+            ];
+            $all[] = $chat;
+            $this->write($user, $all);
+            return $chat;
+        });
     }
 
     public function delete(string $user, string $id): bool {
-        $all = $this->read($user);
-        $kept = array_values(array_filter($all, static fn($c) => ($c['id'] ?? '') !== $id));
-        if (count($kept) === count($all)) {
-            return false;
-        }
-        $this->write($user, $kept);
-        return true;
+        return $this->withUserLock($user, function () use ($user, $id): bool {
+            $all = $this->read($user);
+            $kept = array_values(array_filter($all, static fn($c) => ($c['id'] ?? '') !== $id));
+            if (count($kept) === count($all)) {
+                return false;
+            }
+            $this->write($user, $kept);
+            return true;
+        });
     }
 
     public function setTitle(string $user, string $id, string $title): void {
-        $all = $this->read($user);
-        foreach ($all as &$chat) {
-            if (($chat['id'] ?? '') === $id) {
-                $chat['title'] = $this->clipTitle($title);
-                $chat['updated'] = time();
-                break;
+        $this->withUserLock($user, function () use ($user, $id, $title): void {
+            $all = $this->read($user);
+            foreach ($all as &$chat) {
+                if (($chat['id'] ?? '') === $id) {
+                    $chat['title'] = $this->clipTitle($title);
+                    $chat['updated'] = time();
+                    break;
+                }
             }
-        }
-        unset($chat);
-        $this->write($user, $all);
+            unset($chat);
+            $this->write($user, $all);
+        });
     }
 
     public function append(string $user, string $id, string $role, string $text): void {
         if ($role !== 'user' && $role !== 'assistant') {
             return;
         }
-        $all = $this->read($user);
-        foreach ($all as &$chat) {
-            if (($chat['id'] ?? '') === $id) {
-                $chat['messages'][] = ['role' => $role, 'text' => $text];
-                $chat['updated'] = time();
-                if (count($chat['messages']) > self::MAX_MESSAGES) {
-                    $chat['messages'] = array_slice($chat['messages'], -self::MAX_MESSAGES);
+        $this->withUserLock($user, function () use ($user, $id, $role, $text): void {
+            $all = $this->read($user);
+            foreach ($all as &$chat) {
+                if (($chat['id'] ?? '') === $id) {
+                    $chat['messages'][] = ['role' => $role, 'text' => $text];
+                    $chat['updated'] = time();
+                    if (count($chat['messages']) > self::MAX_MESSAGES) {
+                        $chat['messages'] = array_slice($chat['messages'], -self::MAX_MESSAGES);
+                    }
+                    if (isset($chat['messages'][0]['text']) && str_starts_with($chat['title'] ?? '', 'Neuer Chat')) {
+                        $chat['title'] = $this->clipTitle((string)$chat['messages'][0]['text']);
+                    }
+                    break;
                 }
-                if (isset($chat['messages'][0]['text']) && str_starts_with($chat['title'] ?? '', 'Neuer Chat')) {
-                    $chat['title'] = $this->clipTitle((string)$chat['messages'][0]['text']);
-                }
-                break;
             }
-        }
-        unset($chat);
-        $this->write($user, $all);
+            unset($chat);
+            $this->write($user, $all);
+        });
     }
 
     /** @return list<array{id:string,title:string,created:int,updated:int,messages:list<array{role:string,text:string}>}> */
@@ -130,7 +142,7 @@ class ChatStore {
             return [];
         } catch (NotPermittedException $e) {
             $this->logger->warning('eva_ai: chat folder not readable (permissions?)', ['user' => $user]);
-            return [];
+            throw $e;
         }
         $data = json_decode($raw, true);
         return is_array($data) ? $data : [];
@@ -138,12 +150,36 @@ class ChatStore {
 
     private function write(string $user, array $data): void {
         try {
-            $this->rootFor($user)->putContent(json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            $this->rootFor($user)->putContent($json);
         } catch (\Throwable $e) {
             $this->logger->error('eva_ai: chat save failed - chats may disappear after reload', [
                 'user' => $user,
                 'exception' => $e->getMessage(),
             ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Serialize all chat reads and mutations for one user on this node.
+     * The lock is kept outside AppData because AppData may be object-backed
+     * and does not expose a portable locking primitive.
+     */
+    private function withUserLock(string $user, callable $operation): mixed {
+        $lockPath = sys_get_temp_dir() . '/eva_ai_chat_' . $this->namespaceFor($user) . '.lock';
+        $handle = fopen($lockPath, 'c');
+        if ($handle === false) {
+            throw new \RuntimeException('Unable to create the EVA chat lock');
+        }
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new \RuntimeException('Unable to acquire the EVA chat lock');
+            }
+            return $operation();
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
         }
     }
 

--- a/tests/ChatStoreTest.php
+++ b/tests/ChatStoreTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EvaAi\Tests;
+
+use OCA\EvaAi\Service\ChatStore;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\IAppData;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class ChatStoreTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        if (!defined('EVA_AI_OCP_AVAILABLE') || !EVA_AI_OCP_AVAILABLE) {
+            $this->markTestSkipped('Nextcloud OCP interfaces are not available');
+        }
+    }
+
+    public function testStorageFailureIsPropagatedFromCreate(): void {
+        $factory = $this->createMock(IAppDataFactory::class);
+        $appData = $this->createMock(IAppData::class);
+        $chats = $this->createMock(ISimpleFolder::class);
+        $userFolder = $this->createMock(ISimpleFolder::class);
+        $file = $this->createMock(ISimpleFile::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $factory->method('get')
+            ->with('eva_ai')
+            ->willReturn($appData);
+        $appData->method('getFolder')
+            ->with('chats')
+            ->willReturn($chats);
+        $chats->method('getFolder')
+            ->with(substr(hash('sha256', 'alice'), 0, 40))
+            ->willReturn($userFolder);
+        $userFolder->method('fileExists')
+            ->with('chats.json')
+            ->willReturn(true);
+        $userFolder->method('getFile')
+            ->with('chats.json')
+            ->willReturn($file);
+        $file->expects(self::once())
+            ->method('getContent')
+            ->willReturn('[]');
+        $file->expects(self::once())
+            ->method('putContent')
+            ->willThrowException(new \RuntimeException('storage unavailable'));
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                'eva_ai: chat save failed - chats may disappear after reload',
+                self::arrayHasKey('exception')
+            );
+
+        $store = new ChatStore($factory, $logger);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('storage unavailable');
+        $store->create('alice');
+    }
+}


### PR DESCRIPTION
## Summary

- serialize per-user chat reads and mutations to prevent lost updates
- propagate AppData/JSON persistence failures and return explicit API errors
- add a regression test for failed chat persistence
- resolve README merge-conflict artifacts and stale `eva-ai` command references
- document the actual AppData location and retention of chat history

## Related issues

Closes #34
Closes #35

## Validation

- `composer test` / PHPUnit: 22 tests, 513 assertions
- PHP syntax lint for `lib/` and `tests/`
- `git diff --check`
