### PR TITLE
Quality housekeeping: pending issue contracts, CI audits + nightly compat, FAQ, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Report a problem with EVA (eva_ai)
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please follow the issue format used in this repository (Triage / Summary / Reproduction / Expected behavior / Proposed solution / Acceptance criteria).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - critical (blocks usage / security / data loss)
+        - high (major feature broken)
+        - medium (partial breakage / annoying)
+        - low (cosmetic / edge case)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Chat / Frontend
+        - Indexing / RAG
+        - Search
+        - Calendar tools
+        - Files tools
+        - Shares tools
+        - Mail
+        - Talk bot
+        - TaskProcessing / Assistant
+        - Settings
+        - Security & Privacy
+        - Background jobs
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: Version from info.xml (or git commit/branch)
+      placeholder: e.g. 1.4.0
+    validations:
+      required: true
+
+  - type: input
+    id: nextcloud
+    attributes:
+      label: Nextcloud version
+      placeholder: e.g. 35
+    validations:
+      required: true
+
+  - type: input
+    id: php
+    attributes:
+      label: PHP version
+      placeholder: e.g. 8.3
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is the bug? What did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / screenshots
+      description: nextcloud.log lines (redact personal data), browser console errors, screenshots.
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution (optional)
+      description: If you already know how this should be fixed, describe it here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FAQ
+    url: https://github.com/SchBenedikt/nextcloud-ai/blob/main/docs/FAQ.md
+    about: Common questions and troubleshooting before opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/SchBenedikt/nextcloud-ai/blob/main/docs/SECURITY.md
+    about: Please report security issues as described in docs/SECURITY.md, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest a new feature or improvement for EVA (eva_ai)
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please follow the issue format used in this repository (Triage / Summary / Proposed solution / Acceptance criteria).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - high (important for many users)
+        - medium (nice to have)
+        - low (edge case / polish)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Chat / Frontend
+        - Indexing / RAG
+        - Search
+        - Calendar tools
+        - Files tools
+        - Shares tools
+        - Mail
+        - Talk bot
+        - TaskProcessing / Assistant
+        - Settings
+        - Security & Privacy
+        - Background jobs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should the feature do? Which problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: How could it be implemented? What should the user experience be?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know the feature is done?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Linked issues
+
+<!-- Closes #NN (if this PR fixes an issue). Related: #NN -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / housekeeping
+- [ ] Documentation
+- [ ] Tests / CI
+
+## How has this been tested?
+
+- [ ] `composer test` (PHPUnit) passes
+- [ ] `npm run build` succeeds (if frontend changed)
+- [ ] `php -l` on all changed PHP files
+- [ ] Manual test on the instance (if applicable)
+
+## Checklist
+
+- [ ] README.md updated if user-facing behaviour changed
+- [ ] CHANGELOG.md updated ([Unreleased])
+- [ ] Docs in `docs/` updated if behaviour/configuration changed
+- [ ] New behaviour is covered by tests (or a pending contract test was added for an open issue)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,45 @@
+name: Nightly
+
+on:
+  schedule:
+    # 03:00 UTC every night
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  compat:
+    name: Nextcloud ${{ matrix.nc }} compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nc: ['stable30', 'stable31', 'stable32', 'stable33', 'stable34', 'stable35', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install into Nextcloud ${{ matrix.nc }} and check code
+        run: |
+          docker run --rm \
+            -v "$PWD":/app:ro \
+            -e NC="${{ matrix.nc }}" \
+            ghcr.io/nextcloud/continuous-integration-php8.3 sh -c '
+              set -e
+              if [ "$NC" = "latest" ]; then
+                URL="https://download.nextcloud.com/server/latest.tar.bz2"
+              else
+                URL="https://download.nextcloud.com/server/$NC/latest.tar.bz2"
+              fi
+              echo "== Downloading $URL =="
+              curl -fsSL "$URL" -o /tmp/nc.tar.bz2
+              mkdir -p /srv
+              tar -xjf /tmp/nc.tar.bz2 -C /srv
+              cp -r /app /srv/nextcloud/apps/eva_ai
+              cd /srv/nextcloud/apps/eva_ai
+              composer install --no-interaction --prefer-dist
+              echo "== occ app:check-code eva_ai =="
+              cd /srv/nextcloud
+              php occ app:check-code eva_ai
+              echo "== composer test =="
+              cd /srv/nextcloud/apps/eva_ai
+              composer test
+            '

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,37 @@
+name: Quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  audit:
+    name: Dependency security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Audit composer dependencies
+        run: composer audit --no-interaction
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Audit npm dependencies (production only)
+        run: npm audit --omit=dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,20 @@ follows [Semantic Versioning](https://semver.org/).
 - Docs: `docs/SECURITY.md`, `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`,
   `docs/DEVELOPMENT.md`.
 
+### Housekeeping
+- Pending regression contracts for open issues #99–#106
+  (`tests/OpenIssuesPendingContractTest.php`): each test documents the fix
+  contract and is skipped until the issue is implemented, so CI stays green.
+- New CI workflows: `quality.yml` (composer/npm dependency security audits on
+  push and pull requests) and `nightly.yml` (nightly `occ app:check-code` and
+  the test suite against every supported Nextcloud release line and `latest`).
+- New documentation: `docs/FAQ.md` (setup, indexing, chat, Talk, Assistant and
+  privacy troubleshooting).
+- Issue and pull-request templates (`.github/ISSUE_TEMPLATE/*`,
+  `.github/PULL_REQUEST_TEMPLATE.md`) matching the repository issue format.
+- Backlog grooming: related open issues are cross-linked and small, isolated
+  fixes are labelled `good first issue`.
+
 ## [1.4.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -326,7 +326,8 @@ tools always require explicit user confirmation. See [docs/SECURITY.md](docs/SEC
 
 - **Tests**: `composer test` (PHPUnit) — security, provider, settings and migration regressions
 - **Frontend build**: `npm ci && npm run build`; CI also verifies that the expected generated bundles are emitted
-- **CI**: GitHub Actions on PHP 8.2 / 8.3 / 8.4 (see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md))
+- **CI**: GitHub Actions on PHP 8.2 / 8.3 / 8.4 (see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)), dependency security audits (`quality.yml`) and nightly Nextcloud compatibility checks across all supported release lines (`nightly.yml`)
+- **FAQ**: see [docs/FAQ.md](docs/FAQ.md) for setup, indexing and troubleshooting
 - **Architecture**: see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
 ---

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,177 @@
+# EVA — Frequently Asked Questions (FAQ)
+
+Common questions and troubleshooting. If your problem is not covered here,
+please open an issue using the templates (they follow the same Triage /
+Summary / Reproduction / Expected behavior format used across this repo).
+
+---
+
+## Setup & connection
+
+### "Check connection" fails with my Ollama instance
+
+- Verify the URL is reachable **from the web server**, not from your browser:
+  `http://127.0.0.1:11434` only works when Ollama runs on the same machine as
+  Nextcloud. For another machine use
+  `http://<host>:11434` (e.g. `http://192.168.1.50:11434`).
+- The connection check always uses the endpoint you configured (per user), so a
+  wrong `ollama_url` shows up in the check result.
+- Make sure Ollama listens on the network, not only on localhost:
+  `OLLAMA_HOST=0.0.0.0:11434` (or set `OLLAMA_HOST` in the Ollama systemd unit).
+- HTTP/HTTPS: both are supported, but TLS certificates must be valid
+  (self-signed certificates are rejected).
+
+### Which models do I need?
+
+```bash
+ollama pull gemma4:cloud            # chat model (default)
+ollama pull nomic-embed-text:latest # embeddings (default)
+```
+
+Other chat models usually work too; the embedding model must be a
+text-embedding model.
+
+### Why do I get a 400 error as a non-admin user?
+
+Some endpoints are admin-only by design (global configuration, index
+management). Normal users can use their own settings. If you get a 400/403 on
+a user-facing action, check `nextcloud.log` for the exact message — most tools
+return a German or English explanation.
+
+---
+
+## Indexing
+
+### Indexing takes very long / "Stop" seems to do nothing
+
+The worker only checks for a stop request **between** embedding batches. A
+single batch can take up to 600 s, so stopping can appear unresponsive for a
+few minutes. See issues #65 and #94. The `index_finished` state may also be set
+while the worker is still finishing up — wait for the run to actually finish.
+
+### Starting an index returns 409 Conflict
+
+A 409 means an index run is already active for this user (worker lock).
+Duplicate starts are handled idempotently; a genuine lock conflict is reported
+explicitly. Wait for the running pass to finish or stop it first.
+
+### A document expands but shows "no chunks"
+
+This happens when chunk rows for the document are missing or were dropped.
+Known related problems: the chunker previously removed duplicate paragraphs
+(issue #62) and the extraction may deliver partial content (issue #66). The
+document is usually not re-chunked until its content changes — use
+`occ eva_ai:index <user>` to re-run the pass.
+
+### Documents load slowly / not all documents appear at once
+
+The document list is paginated and loads more entries via **"Load more"**.
+Chunk inspection of very large documents loads all chunks at once (issue #91)
+— for very large files this can take a moment.
+
+### How do I exclude folders from indexing?
+
+Use **Settings → Indexing & scope** → **Exclude paths** (comma-separated path
+prefixes) and save. Exclusions are stored per user and applied on the next
+indexing pass.
+
+### Which formats are indexed?
+
+Text, Markdown, code, CSV/TSV, HTML, JSON, XML, YAML, TOML, RTF, SQL, PDF,
+Office (docx/xlsx/pptx incl. macro/template variants), OpenDocument
+(odt/ods/odp), EPUB and more. Full-content extraction of all Office formats is
+tracked in issues #60 and #66.
+
+---
+
+## Chat & tools
+
+### The answer doesn't see the whole document
+
+In the **file-context chat** (right-click → "Open with EVA") the model receives
+a bounded excerpt of the selected files (issue #63). In the **normal chat** the
+RAG retrieval picks the most relevant chunks — very large indexes can miss
+semantic-only matches (issue #61).
+
+### EVA always answers in the wrong language
+
+EVA answers in the language of your question. KNOWLEDGE.md and retrieved
+context are taken into account; if you want a fixed behaviour, put an
+instruction in `KNOWLEDGE.md` (e.g. "Always answer in German.").
+
+### EVA knows personal facts about me — where do they come from?
+
+On first use, EVA writes a small `KNOWLEDGE.md` profile section into your home
+folder (user ID, display name, optional email). You can edit or delete it
+anytime; it is never overwritten automatically. See docs/PRIVACY.md.
+
+### The weather tool sends data to Open-Meteo — can I disable it?
+
+Currently there is no opt-out setting (issue #69). The weather tool only sends
+the location name to `open-meteo.com`. Disable the tools entirely in Settings
+("Enable chat tools") if you don't want any external call.
+
+### My chat history is long — is everything kept?
+
+Chats are stored per user in the app data. Very long conversations are
+silently bounded (issue #96); agent conversations are bounded as well
+(issue #105).
+
+---
+
+## Nextcloud Talk bot
+
+### The bot does not appear in a conversation
+
+The bot registers on app boot when Talk is enabled. Activate it per
+conversation in the conversation settings ("Bots"). Re-register explicitly:
+
+```bash
+sudo -u www-data php occ eva_ai:talk:setup
+```
+
+### Which documents does the bot use?
+
+The bot answers based on the indexed documents of the user who added it
+(optionally with the last `talk_history_size` messages as context).
+
+---
+
+## Nextcloud Assistant / TaskProcessing
+
+### Tasks stay "scheduled" and never run
+
+TaskProcessing needs a worker cron:
+
+```bash
+sudo -u www-data php occ taskprocessing:task-type:set-enabled core:text2text:chat 1
+```
+
+and a cron entry, e.g. `/etc/cron.d/eva_ai-taskprocessing`:
+
+```
+* * * * * www-data /usr/bin/php -d error_reporting=0 /var/www/nextcloud/occ taskprocessing:worker -t 60 -i 2 >/dev/null 2>&1
+```
+
+### Why do the provider names differ between surfaces?
+
+The Assistant app shows the provider labels `Eva · Local`, `Eva · RAG`,
+`Eva · Tools`, `Eva · Agent`. Some Assistants versions add the task type to the
+name, so the same provider can appear as "Eva (local) RAG Chat (Ollama)" or
+"Eva". This is a naming inconsistency of the host app — the underlying
+providers are identical.
+
+---
+
+## Privacy & data
+
+### Where is my data stored?
+
+Everything runs on your own server. See the data-lifecycle table in
+docs/PRIVACY.md (documents, chunks, chat history, agent state, app
+configuration) and the reset commands (`occ eva_ai:reset`).
+
+### Are external services used?
+
+Only optionally: the weather tool calls Open-Meteo (see above). The RAG
+indexing, embeddings and chat all run against your local Ollama instance.

--- a/tests/OpenIssuesPendingContractTest.php
+++ b/tests/OpenIssuesPendingContractTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EvaAi\Tests;
+
+use OCA\EvaAi\Service\ActionExecutor;
+use OCA\EvaAi\Service\AppConfig;
+use OCA\EvaAi\Service\Ollama;
+use OCA\EvaAi\Service\SharesService;
+use OCA\EvaAi\TaskProcessing\TextToTextChatWithToolsProvider;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IL10N;
+use OCP\Share\IManager as ShareManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Pending regression contracts for the open GitHub issues #99–#106.
+ *
+ * Each test asserts the contract that the FIX must guarantee. The tests are
+ * marked `markTestSkipped()` until the corresponding issue is implemented, so
+ * CI stays green while the intended behaviour is documented and executable.
+ *
+ * When you fix an issue:
+ *   1. remove the `markTestSkipped(...)` line of that test,
+ *   2. the assertions below then verify the fix and guard against regressions.
+ */
+final class OpenIssuesPendingContractTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		if (!defined('EVA_AI_OCP_AVAILABLE') || !EVA_AI_OCP_AVAILABLE) {
+			$this->markTestSkipped('Nextcloud OCP interfaces are not available');
+		}
+	}
+
+	/**
+	 * Issue #99: recurring events (RRULE) must be expanded in
+	 * list_calendar_events and find_free_slots.
+	 */
+	public function testIssue99RecurringEventsAreExpanded(): void {
+		$this->markTestSkipped('Fix for issue #99 (RRULE expansion) is not implemented yet');
+		$calendar = (string)file_get_contents(__DIR__ . '/../lib/Service/CalendarService.php');
+		$listSlice = $this->sliceBetween($calendar, 'public function listEvents', 'public function createEvent');
+		self::assertStringContainsString('EventIterator', $listSlice, 'list_calendar_events must expand recurrences (RRULE)');
+		$slotSlice = $this->sliceToEnd($calendar, 'public function findFreeSlots');
+		self::assertStringContainsString('EventIterator', $slotSlice, 'find_free_slots must expand recurrences (RRULE)');
+	}
+
+	/**
+	 * Issue #100: link-share tokens and public URLs must not reach the tool
+	 * output (LLM context / persisted chat history).
+	 */
+	public function testIssue100ShareTokensAreRedactedFromToolOutput(): void {
+		$this->markTestSkipped('Fix for issue #100 (share token redaction) is not implemented yet');
+
+		$link = $this->createMock(IShare::class);
+		$link->method('getToken')->willReturn('leakable-secret-token-123');
+		$link->method('getShareType')->willReturn(IShare::TYPE_LINK);
+		$link->method('getSharedWith')->willReturn('');
+		$link->method('getExpirationDate')->willReturn(null);
+		$link->method('getNote')->willReturn('');
+		$link->method('getId')->willReturn(11);
+		$node = $this->createMock(Node::class);
+		$node->method('getPath')->willReturn('/alice/files/report.pdf');
+		$link->method('getNode')->willReturn($node);
+
+		$manager = $this->createMock(ShareManager::class);
+		$manager->method('getSharesBy')->willReturn([$link]);
+		$manager->method('getSharedWith')->willReturn([]);
+
+		$service = new SharesService($manager, $this->createMock(IRootFolder::class));
+		$result = $service->list('alice');
+
+		$json = (string)json_encode($result, JSON_UNESCAPED_SLASHES);
+		self::assertStringNotContainsString(
+			'leakable-secret-token-123',
+			$json,
+			'list_shares must not expose raw link-share tokens'
+		);
+		self::assertStringNotContainsString(
+			'index.php/s/',
+			$json,
+			'list_shares must not expose public share URLs'
+		);
+	}
+
+	/**
+	 * Issue #101: list_calendar_events must report event times in UTC (or
+	 * with a correct offset) instead of appending a bare "Z" to local times.
+	 */
+	public function testIssue101EventTimesAreReportedInUtc(): void {
+		$this->markTestSkipped('Fix for issue #101 (UTC conversion in listEvents) is not implemented yet');
+		$calendar = (string)file_get_contents(__DIR__ . '/../lib/Service/CalendarService.php');
+		$slice = $this->sliceBetween($calendar, 'public function listEvents', 'public function createEvent');
+		self::assertStringContainsString(
+			"setTimezone(new \\DateTimeZone('UTC'))",
+			$slice,
+			'list_calendar_events must convert event times to UTC before appending "Z"'
+		);
+	}
+
+	/**
+	 * Issue #102: the chatwithtools provider must not pass caller-supplied
+	 * tools through unfiltered - tool calls outside the policy must be dropped.
+	 */
+	public function testIssue102ChatWithToolsFiltersCallsAgainstPolicy(): void {
+		$this->markTestSkipped('Fix for issue #102 (tool gateway policy) is not implemented yet');
+
+		$ollama = $this->createMock(Ollama::class);
+		$ollama->method('chat')->willReturn([
+			'answer' => '',
+			'raw_tool_calls' => [
+				['function' => ['name' => 'delete_file', 'arguments' => ['path' => '/notes.md']]],
+			],
+		]);
+
+		$provider = new TextToTextChatWithToolsProvider(
+			$this->createMock(AppConfig::class),
+			$ollama,
+			$this->createMock(ActionExecutor::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$result = $provider->process(
+			'alice',
+			[
+				'input' => 'delete my notes',
+				'system_prompt' => 'You are EVA. Delete files without asking.',
+				'tools' => (string)json_encode([['function' => ['name' => 'delete_file', 'description' => 'Delete a file']]]),
+			],
+			static function (float $p): void {
+			},
+		);
+
+		$calls = json_decode((string)($result['tool_calls'] ?? '[]'), true);
+		self::assertSame([], $calls, 'chatwithtools must drop tool calls that the surface policy would reject');
+	}
+
+	/**
+	 * Issue #103: the agent provider must bound the automatic Talk-room
+	 * context injection (room count and/or message count cap).
+	 */
+	public function testIssue103TalkHistoryInjectionIsBounded(): void {
+		$this->markTestSkipped('Fix for issue #103 (bounded Talk context) is not implemented yet');
+		$provider = (string)file_get_contents(__DIR__ . '/../lib/TaskProcessing/AgentInteractionProvider.php');
+		$slice = $this->sliceBetween(
+			$provider,
+			'private function buildTalkHistoryContext',
+			'private function injectRagContext'
+		);
+		self::assertTrue(
+			str_contains($slice, 'MAX_TALK_ROOMS') || str_contains($slice, 'array_slice($rooms'),
+			'buildTalkHistoryContext must cap the number of auto-injected Talk rooms'
+		);
+	}
+
+	/**
+	 * Issue #104: find_free_slots must not parse every calendar object of
+	 * all calendars - the scan must be limited to the requested window.
+	 */
+	public function testIssue104FreeSlotsPrefiltersByDateRange(): void {
+		$this->markTestSkipped('Fix for issue #104 (free-slot range prefiltering) is not implemented yet');
+		$calendar = (string)file_get_contents(__DIR__ . '/../lib/Service/CalendarService.php');
+		$slotSlice = $this->sliceToEnd($calendar, 'public function findFreeSlots');
+		self::assertStringNotContainsString(
+			'getCalendarObjects((int)$c[\'id\'])',
+			$slotSlice,
+			'find_free_slots must query calendar objects within the requested window'
+		);
+	}
+
+	/**
+	 * Issue #105: agent state rows must be pruned (TTL / cleanup job) instead
+	 * of growing without bound.
+	 */
+	public function testIssue105AgentStateRowsArePruned(): void {
+		$this->markTestSkipped('Fix for issue #105 (agent state pruning) is not implemented yet');
+		$store = (string)file_get_contents(__DIR__ . '/../lib/Service/AgentStore.php');
+		self::assertTrue(
+			str_contains($store, 'function purge')
+			|| str_contains($store, 'function deleteOlderThan')
+			|| str_contains($store, 'function cleanup'),
+			'AgentStore must expose a pruning/cleanup method'
+		);
+	}
+
+	/**
+	 * Issue #106: share lookup must resolve by id first so shares beyond the
+	 * first 500 per type can be updated and deleted.
+	 */
+	public function testIssue106ShareLookupUsesIdFirst(): void {
+		$this->markTestSkipped('Fix for issue #106 (share id lookup) is not implemented yet');
+		$shares = (string)file_get_contents(__DIR__ . '/../lib/Service/SharesService.php');
+		self::assertStringContainsString(
+			'getShareById',
+			$shares,
+			'findOwnShare must resolve shares by id before iterating'
+		);
+	}
+
+	private function sliceBetween(string $haystack, string $start, string $end): string {
+		$s = strpos($haystack, $start);
+		self::assertNotFalse($s, "start marker '$start' not found");
+		$e = strpos($haystack, $end, $s);
+		self::assertNotFalse($e, "end marker '$end' not found");
+		return substr($haystack, $s, $e - $s);
+	}
+
+	private function sliceToEnd(string $haystack, string $start): string {
+		$s = strpos($haystack, $start);
+		self::assertNotFalse($s, "start marker '$start' not found");
+		return substr($haystack, $s);
+	}
+}


### PR DESCRIPTION
## Summary

Non-code quality housekeeping: pending regression contracts for the open issues #99–#106, extended CI (dependency audits + nightly Nextcloud compatibility), new FAQ documentation, and issue/PR templates. No production code is changed.

## Changes

### Tests
- **`tests/OpenIssuesPendingContractTest.php`** (new): pending regression contracts for open issues **#99 (RRULE expansion)**, **#100 (share-token redaction)**, **#101 (UTC time reporting)**, **#102 (chatwithtools policy gateway)**, **#103 (bounded Talk context)**, **#104 (free-slot range prefiltering)**, **#105 (agent-state pruning)** and **#106 (share lookup by id)**. Each test is `markTestSkipped()` until the issue is implemented — CI stays green, and removing the skip line when fixing an issue verifies the fix and guards against regressions.

### CI (`.github/workflows/`)
- **`quality.yml`** (new): `composer audit` and `npm audit` (production deps) on every push and PR.
- **`nightly.yml`** (new): nightly run installing the app into Nextcloud `stable30`–`stable35` plus `latest`, running `occ app:check-code` and the full test suite — catches breakage when Nextcloud releases updates. Also manually triggerable via `workflow_dispatch`.

### Docs
- **`docs/FAQ.md`** (new): setup, indexing, chat/tools, Talk, Assistant and privacy troubleshooting, based on verified issues and common user reports.
- **`CHANGELOG.md`**: added a `Housekeeping` section under `[Unreleased]`.
- **`README.md`**: link to the FAQ and mention the new workflows in the Development section.

### GitHub templates (`.github/`)
- **`ISSUE_TEMPLATE/bug_report.yml`**, **`ISSUE_TEMPLATE/feature_request.yml`** (form-based, matching the repo's Triage/Summary/…/Acceptance-criteria issue format), **`ISSUE_TEMPLATE/config.yml`** and **`PULL_REQUEST_TEMPLATE.md`**.

### Backlog grooming (GitHub)
- Related open issues cross-linked via comments (#63↔#91, #65↔#94, #62↔#66, #68↔#95, #77↔#85, #96↔#105, #93↔#72, #67↔#102).
- Small, isolated fixes labelled `good first issue` (#71, #76, #96, #97, #101, #104, #105, #106).

## Verification

- `composer test`: 55 tests, 799 assertions, 8 skipped (the pending contracts) — all green.
- `php -l` on the new test file, YAML validation of the new workflows.
- Also fixed a pre-existing repo permission issue: root-owned object directories in `.git/objects` (from earlier agent sessions) blocked `git add` — re-chowned to `www-data`.
