### PR TITLE
Fix: inject LoggerInterface into RagService so the access-revocation purge path can actually log (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issue #71**: `RagService` now receives a `LoggerInterface` through
+  constructor injection, so the access-revocation purge path no longer
+  throws an undefined-property error that was silently swallowed by the
+  surrounding `try`/`catch`; the audit log entry is now actually written.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/lib/Service/RagService.php
+++ b/lib/Service/RagService.php
@@ -8,6 +8,7 @@ use OCA\EvaAi\Db\ChunkMapper;
 use OCA\EvaAi\Db\DocumentMapper;
 use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class RagService {
     private const MAX_TOOL_ROUNDS = 4;
@@ -20,7 +21,8 @@ class RagService {
         private ChunkMapper $chunkMapper,
         private IURLGenerator $urlGenerator,
         private ActionExecutor $executor,
-        private IRootFolder $rootFolder
+        private IRootFolder $rootFolder,
+        private LoggerInterface $logger
     ) {
     }
 

--- a/tests/RagServiceLoggerRegressionTest.php
+++ b/tests/RagServiceLoggerRegressionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EvaAi\Tests;
+
+use OCA\EvaAi\Service\RagService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for issue #71: RagService::filterAccessible() called
+ * $this->logger->info(...) in the access-revocation purge path, but no
+ * logger was ever injected into RagService. That threw an undefined
+ * property \Error which was silently swallowed by the surrounding
+ * try/catch, so the audit log entry was never written.
+ *
+ * This does not require a running Nextcloud instance: reflecting on the
+ * constructor signature does not need the referenced OCP classes to be
+ * loadable, only declared.
+ */
+final class RagServiceLoggerRegressionTest extends TestCase {
+    public function testConstructorRequiresAPsrLogger(): void {
+        $reflection = new \ReflectionClass(RagService::class);
+        $constructor = $reflection->getConstructor();
+        self::assertNotNull($constructor, 'RagService must declare a constructor');
+
+        $loggerParam = null;
+        foreach ($constructor->getParameters() as $parameter) {
+            if ($parameter->getName() === 'logger') {
+                $loggerParam = $parameter;
+                break;
+            }
+        }
+
+        self::assertNotNull($loggerParam, 'RagService constructor must accept a $logger parameter');
+        $type = $loggerParam->getType();
+        self::assertNotNull($type, '$logger parameter must be typed');
+        self::assertSame(\Psr\Log\LoggerInterface::class, (string)$type, '$logger must be typed as Psr\\Log\\LoggerInterface so Nextcloud\'s DI container can autowire it');
+
+        // Constructor-promoted properties do not appear as separate class
+        // properties, so this also proves $this->logger is now a real,
+        // defined property instead of an undefined one.
+        self::assertTrue($reflection->hasProperty('logger'), 'RagService must have a $logger property backing $this->logger');
+    }
+
+    public function testPurgePathLogsThroughTheInjectedLogger(): void {
+        $source = (string)file_get_contents(__DIR__ . '/../lib/Service/RagService.php');
+        $start = strpos($source, 'private function filterAccessible');
+        self::assertNotFalse($start, 'filterAccessible() must exist');
+        $method = substr($source, $start);
+
+        self::assertStringContainsString('$this->logger->info(', $method, 'the purge path must still log via $this->logger');
+    }
+}


### PR DESCRIPTION
# Fix: inject LoggerInterface into RagService so the access-revocation purge path can actually log (#71)

## Summary

`RagService::filterAccessible()` calls `$this->logger->info(...)` when purging a stale RAG document whose backing file access was revoked, but `RagService` never received a logger through its constructor. `$this->logger` was an undefined property, so the call threw a PHP `Error` that was silently swallowed by the surrounding `try`/`catch (\Throwable)`. The purge itself still completed, but no audit log entry was ever written, and the class would fail a strict static-analysis run.

## Linked issues

Closes #71

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / housekeeping
- [ ] Documentation
- [ ] Tests / CI

## What changed

- `lib/Service/RagService.php`: added `private LoggerInterface $logger` as a constructor-promoted parameter (imported `Psr\Log\LoggerInterface`), following the same pattern already used by `Ollama`, `Indexer`, `ChatStore`, and other services in this codebase. Nextcloud's DI container autowires `LoggerInterface`, so no call site needed to change — I confirmed there are no manual `new RagService(...)` constructions anywhere in `lib/` or `tests/`.
- `tests/RagServiceLoggerRegressionTest.php` (new): a regression test that (1) reflects on `RagService`'s constructor to assert it declares a `$logger` parameter typed `Psr\Log\LoggerInterface` and that `$logger` is a real class property (i.e. no longer undefined), and (2) asserts the purge path in `filterAccessible()` still calls `$this->logger->info(...)`. This test does not require a live Nextcloud instance/`NEXTCLOUD_ROOT`, so it runs (and is asserted, not skipped) in plain `composer test`.
- `CHANGELOG.md`: added an `[Unreleased] / Fixed` entry for issue #71, matching the existing per-issue changelog convention in this file.

## How has this been tested?

- [x] `composer test` (PHPUnit) passes — before the fix: 55 tests, 485 assertions, 30 skipped, OK. After the fix (including the two new regression tests): **57 tests, 492 assertions, 30 skipped, OK**. No test regressed or gained a new skip.
- [ ] `npm run build` succeeds (if frontend changed) — not applicable, no frontend files were touched.
- [x] `php -l` on all changed PHP files — ran the exact CI command from `.github/workflows/tests.yml`'s `lint` job: `find lib tests -name '*.php' -print0 | xargs -0 -n1 php -l`. No syntax errors on any file (58/58 clean).
- [ ] Manual test on the instance (if applicable) — not performed; this is a constructor-injection fix with no behavioral surface beyond restoring the intended log call, and DI autowiring for `LoggerInterface` is already exercised by other services in this same app.

Also ran the repo's targeted regression job for good measure: `vendor/bin/phpunit --colors=always tests/MigrationRegressionTest.php tests/TaskProcessingContractTest.php tests/AppConfigUserSettingsTest.php` → 13 tests, 17 assertions, 10 skipped, OK (unaffected by this change, run only to confirm no cross-test breakage).

## Checklist

- [ ] README.md updated if user-facing behaviour changed — not needed; this is an internal reliability fix with no user-facing behavior change.
- [x] CHANGELOG.md updated ([Unreleased])
- [ ] Docs in `docs/` updated if behaviour/configuration changed — not needed; no configuration or documented behavior changed.
- [x] New behaviour is covered by tests (or a pending contract test was added for an open issue)
