### PR TITLE
Harden Talk privacy and share tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issues #95, #100 and #103**: Talk blocks sensitive profile/share/server-status tools, existing share listings redact link capability secrets and URLs, and TaskProcessing only injects explicitly supplied Talk rooms with caps of three rooms and 20 recent messages per room.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ always cite the source file path the model took the information from.
 - **Broad format support**: text (txt, md, code, csv, tsv, html, json, xml, yaml,
   toml, rtf, sql, …), PDF, Office (docx/xlsx/pptx incl. macro/template variants),
   OpenDocument (odt, ods, odp), EPUB and more
-- **Chat tools** (toggleable, risk-classified — see [Security](docs/SECURITY.md)):
+- **Chat tools** (toggleable, risk-classified — see [Security](docs/SECURITY.md)); Talk blocks sensitive profile, share-listing and server-status tools
   - **Files**: list, create, rename, delete, read, search, notes, personal knowledge base (`KNOWLEDGE.md`)
   - **Contacts**: find, create, update, delete (own, shared, group and Circles address books)
   - **Calendar**: list calendars/events, create/update/delete events, reminders, free-slot search
@@ -135,8 +135,7 @@ sudo -u www-data php occ eva_ai:talk:setup --remove                 # remove the
 sudo -u www-data php occ eva_ai:talk:setup --name="EVA" --description="Local RAG assistant"
 ```
 
-The bot answers based on the indexed documents of the user who added it, and it
-receives the last `talk_history_size` messages as context.
+The bot answers based on the indexed documents of the user who added it. TaskProcessing only receives Talk history when room IDs are explicitly supplied, limited to three rooms and the latest 20 messages per room; it never loads every room automatically. Sensitive tools such as profile, share-listing and server-status access are unavailable in Talk.
 
 ### 8. File-context chat from the Files app (optional)
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -242,7 +242,7 @@ Gets how many unread emails the user currently has. No parameters.
 ## Shares
 
 ### list_shares
-Lists all file/folder shares of the user: outgoing (link + user/group shares) and incoming shares from others, with expiry, note and link.
+Lists file/folder shares of the user: outgoing and incoming shares with expiry and note. Existing public-link tokens and URLs are redacted; a newly created link returns its URL once.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,7 +31,9 @@ Every tool is registered centrally with three properties:
 
 ### Risk classification
 
-- **readonly** — no side effects. Safe on every surface:
+- **readonly** — no side effects. Most are safe on every surface. Sensitive
+  profile, share-listing and server-status reads are intentionally unavailable
+  on Talk:
   `list_files`, `read_file`, `search_files`, `find_contact`, `read_profile`,
   `list_calendars`, `list_calendar_events`, `find_free_slots`, `search_mails`,
   `list_mails`, `read_mail`, `unread_mail_count`, `list_shares`, `list_tasks`,
@@ -53,14 +55,14 @@ Not every surface may run every tool:
 | Surface | Context | Mutating tools allowed? |
 |---|---|---|
 | `web` | EVA web chat UI | ✅ yes (with confirmation) |
-| `talk` | Nextcloud Talk bot | ✅ yes (with confirmation) |
+| `talk` | Nextcloud Talk bot | ✅ yes (with confirmation), but sensitive profile/share/server-status reads are blocked |
 | `rag` | RAG pipeline internals | ❌ no — only readonly tools |
 | `taskprocessing` | Assistant app / background workers | ❌ no — only readonly tools (before user confirmation) |
 
 This prevents a background job or the Assistant app from silently creating,
-deleting or overwriting data. The `AgentInteractionProvider` switches the surface
-to `web` **only after** the user confirmed a proposed tool call, so the
-confirmation flow keeps working in TaskProcessing.
+deleting or overwriting data. Talk additionally does not expose profile details, existing share listings or instance server status. The `AgentInteractionProvider` switches the surface to `web` **only after** the user confirmed a proposed tool call, so the confirmation flow keeps working in TaskProcessing.
+
+Talk history is opt-in: TaskProcessing only accepts explicitly supplied room IDs and caps the context at three rooms and the latest 20 messages per room. It never discovers and injects every room automatically.
 
 ### Enforcement point
 

--- a/lib/Service/SharesService.php
+++ b/lib/Service/SharesService.php
@@ -133,7 +133,10 @@ class SharesService {
         } catch (\Throwable $e) {
             return ['ok' => false, 'error' => 'Share failed: ' . $e->getMessage()];
         }
-        return ['ok' => true, 'result' => $this->describe($share, 'outgoing')];
+        // A newly created link may return its URL once so the user can act
+        // on it. Existing-share listings and updates never expose capability
+        // tokens or public URLs.
+        return ['ok' => true, 'result' => $this->describe($share, 'outgoing', true)];
     }
 
     /** @return array{ok:true,result:array}|array{ok:false,error:string} */
@@ -203,7 +206,7 @@ class SharesService {
     }
 
     /** @return array{path:string,type:string,recipient:string,token:string,url:string,expiration:?string,note:string,permissions:int} */
-    private function describe(IShare $share, string $direction): array {
+    private function describe(IShare $share, string $direction, bool $includeNewLinkUrl = false): array {
         $path = '/';
         try {
             $path = $share->getNode()->getPath();
@@ -214,9 +217,10 @@ class SharesService {
             }
         } catch (\Throwable $e) {
         }
-        $token = $share->getToken() ?? '';
+        $isLink = $share->getShareType() === IShare::TYPE_LINK;
+        $token = $includeNewLinkUrl && $isLink ? ($share->getToken() ?? '') : '';
         $url = '';
-        if ($token !== '' && $share->getShareType() === IShare::TYPE_LINK &&
+        if ($includeNewLinkUrl && $token !== '' && $isLink &&
             class_exists(\OCP\Server::class)) {
             try {
                 $url = \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token]);
@@ -241,7 +245,9 @@ class SharesService {
             'type' => $this->typeName($share->getShareType()),
             'path' => $path,
             'recipient' => (string)($share->getSharedWith() ?? ''),
-            'token' => $token,
+            // A token is a capability secret. Keep the field shape stable for
+            // existing callers, but never return the actual value.
+            'token' => $isLink ? '[redacted]' : '',
             'url' => $url,
             'expiration' => $exp,
             'note' => $note,

--- a/lib/Service/ToolPolicy.php
+++ b/lib/Service/ToolPolicy.php
@@ -117,9 +117,9 @@ class ToolPolicy {
         // ---- Profile ----
         'read_profile' => [
             'risk' => self::RISK_READONLY,
-            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TALK, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
+            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
             'requiresConfirmation' => false,
-            'description' => 'Read own profile',
+            'description' => 'Read own profile (not available in Talk)',
         ],
         'update_profile' => [
             'risk' => self::RISK_MUTATING,
@@ -195,9 +195,9 @@ class ToolPolicy {
         // ---- Shares ----
         'list_shares' => [
             'risk' => self::RISK_READONLY,
-            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TALK, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
+            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
             'requiresConfirmation' => false,
-            'description' => 'List shares',
+            'description' => 'List shares (not available in Talk)',
         ],
         'create_share' => [
             'risk' => self::RISK_MUTATING,
@@ -259,9 +259,9 @@ class ToolPolicy {
         ],
         'server_status' => [
             'risk' => self::RISK_READONLY,
-            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TALK, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
+            'surfaces' => [self::SURFACE_WEB, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
             'requiresConfirmation' => false,
-            'description' => 'Get server status',
+            'description' => 'Get server status (not available in Talk)',
         ],
         'current_time' => [
             'risk' => self::RISK_READONLY,

--- a/lib/TaskProcessing/AgentInteractionProvider.php
+++ b/lib/TaskProcessing/AgentInteractionProvider.php
@@ -36,6 +36,9 @@ class AgentInteractionProvider implements ISynchronousProvider {
 	 * proposal phase without user confirmation; their results are fed back to
 	 * the model so it can propose a complete chain of modifying actions.
 	 */
+	private const MAX_TALK_ROOMS = 3;
+	private const MAX_TALK_MESSAGES_PER_ROOM = 20;
+
 	private const READ_ONLY_TOOLS = [
 		'list_files', 'read_file', 'search_files',
 		'find_contact', 'read_profile',
@@ -169,10 +172,9 @@ class AgentInteractionProvider implements ISynchronousProvider {
 
 		$system = $this->buildPrompt($userId, $confirmation, $pending, $talkRoomIds, $ragEnabled);
 		$messages = [['role' => 'system', 'content' => $system]];
-		// Talk-Verlauf injizieren:
-		// 1. Explizit über talk_room_ids (falls übergeben)
-		// 2. Automatisch alle Talk-Räume des Users (falls Talk installiert)
-		$talkHistory = $this->buildTalkHistoryContext($talkRoomIds, $userId);
+		// Talk-Verlauf wird ausschließlich bei explizit übergebenen Room-IDs
+		// injiziert. Niemals automatisch alle Räume des Users laden.
+		$talkHistory = $this->buildTalkHistoryContext($talkRoomIds);
 		if (!empty($talkHistory)) {
 			foreach ($talkHistory as $h) {
 				$messages[] = $h;
@@ -397,40 +399,27 @@ class AgentInteractionProvider implements ISynchronousProvider {
 	}
 
 	/**
-	 * Baut Talk-Verlauf auf. Nutzt explizit übergebene Room-IDs oder
-	 * automatisch alle Talk-Räume des Users (wenn Talk installiert ist).
+	 * Baut Talk-Verlauf nur für explizit übergebene Room-IDs auf.
+	 * The context is deliberately bounded because room messages may contain
+	 * private data from other participants.
 	 *
-	 * @param list<string|int> $talkRoomIds Explizit übergebene Room-IDs
-	 * @param string $userId Benutzer für automatische Raum-Erkennung
+	 * @param list<string|int> $talkRoomIds Explicitly opted-in room IDs
 	 * @return list<array{role:string,content:string}>
 	 */
-	private function buildTalkHistoryContext(array $talkRoomIds, string $userId): array {
-		// Falls explizit Room-IDs übergeben wurden, nur diese verwenden
-		$rooms = $talkRoomIds;
-		if (empty($rooms) && class_exists('\\OCA\\Talk\\Manager')) {
-			// Automatisch alle Talk-Räume des Users finden
-			try {
-				$talkManager = \OC::$server->get(\OCA\Talk\Manager::class);
-				if ($talkManager !== null) {
-					$rooms = array_map(static fn($r): int => (int)$r->getId(), $talkManager->getRoomsForUser($userId, false, false));
-				}
-			} catch (\Throwable $e) {
-				// Talk nicht verfügbar oder Fehler - ignorieren
-				$rooms = [];
-			}
-		}
-
+	private function buildTalkHistoryContext(array $talkRoomIds): array {
+		$rooms = array_values(array_unique(array_filter(
+			array_map('intval', $talkRoomIds),
+			static fn(int $roomId): bool => $roomId > 0
+		)));
+		$rooms = array_slice($rooms, 0, self::MAX_TALK_ROOMS);
 		$context = [];
-		foreach ($rooms as $roomIdRaw) {
-			$roomId = (int)$roomIdRaw;
-			if ($roomId <= 0) {
-				continue;
-			}
+		foreach ($rooms as $roomId) {
 			try {
 				$talkHistory = $this->talkContextReader->buildHistoryMessages($roomId);
 			} catch (\Throwable $e) {
 				continue;
 			}
+			$talkHistory = array_slice($talkHistory, -self::MAX_TALK_MESSAGES_PER_ROOM);
 			if ($talkHistory === []) {
 				continue;
 			}

--- a/tests/OpenIssuesPendingContractTest.php
+++ b/tests/OpenIssuesPendingContractTest.php
@@ -20,9 +20,9 @@ use Psr\Log\LoggerInterface;
 /**
  * Pending regression contracts for the open GitHub issues #99–#106.
  *
- * Each test asserts the contract that the FIX must guarantee. The tests are
- * marked `markTestSkipped()` until the corresponding issue is implemented, so
- * CI stays green while the intended behaviour is documented and executable.
+ * Each test asserts the contract that the fix must guarantee. Contracts for
+ * issues already implemented in a focused PR run as active regression tests;
+ * the remaining contracts stay skipped until their issue is implemented.
  *
  * When you fix an issue:
  *   1. remove the `markTestSkipped(...)` line of that test,
@@ -55,15 +55,13 @@ final class OpenIssuesPendingContractTest extends TestCase {
 	 * output (LLM context / persisted chat history).
 	 */
 	public function testIssue100ShareTokensAreRedactedFromToolOutput(): void {
-		$this->markTestSkipped('Fix for issue #100 (share token redaction) is not implemented yet');
-
 		$link = $this->createMock(IShare::class);
 		$link->method('getToken')->willReturn('leakable-secret-token-123');
 		$link->method('getShareType')->willReturn(IShare::TYPE_LINK);
 		$link->method('getSharedWith')->willReturn('');
 		$link->method('getExpirationDate')->willReturn(null);
 		$link->method('getNote')->willReturn('');
-		$link->method('getId')->willReturn(11);
+		$link->method('getId')->willReturn('11');
 		$node = $this->createMock(Node::class);
 		$node->method('getPath')->willReturn('/alice/files/report.pdf');
 		$link->method('getNode')->willReturn($node);
@@ -146,17 +144,15 @@ final class OpenIssuesPendingContractTest extends TestCase {
 	 * context injection (room count and/or message count cap).
 	 */
 	public function testIssue103TalkHistoryInjectionIsBounded(): void {
-		$this->markTestSkipped('Fix for issue #103 (bounded Talk context) is not implemented yet');
 		$provider = (string)file_get_contents(__DIR__ . '/../lib/TaskProcessing/AgentInteractionProvider.php');
 		$slice = $this->sliceBetween(
 			$provider,
 			'private function buildTalkHistoryContext',
 			'private function injectRagContext'
 		);
-		self::assertTrue(
-			str_contains($slice, 'MAX_TALK_ROOMS') || str_contains($slice, 'array_slice($rooms'),
-			'buildTalkHistoryContext must cap the number of auto-injected Talk rooms'
-		);
+		self::assertStringContainsString('MAX_TALK_ROOMS', $slice);
+		self::assertStringContainsString('MAX_TALK_MESSAGES_PER_ROOM', $slice);
+		self::assertStringNotContainsString('getRoomsForUser', $slice);
 	}
 
 	/**

--- a/tests/ToolPolicySecurityTest.php
+++ b/tests/ToolPolicySecurityTest.php
@@ -66,12 +66,13 @@ class ToolPolicySecurityTest extends TestCase {
         }
     }
 
-    public function testTalkSurfaceAllowsAllTools(): void {
+    public function testTalkSurfaceBlocksSensitiveInstanceAndProfileTools(): void {
         $this->policy->setSurface(ToolPolicy::SURFACE_TALK);
-        foreach ($this->policy->allToolNames() as $tool) {
-            $result = $this->policy->check($tool);
-            $this->assertTrue($result['allowed'], "Tool '$tool' should be allowed on talk surface");
-        }
+        self::assertTrue($this->policy->check('list_files')['allowed']);
+        self::assertTrue($this->policy->check('current_time')['allowed']);
+        self::assertFalse($this->policy->check('read_profile')['allowed']);
+        self::assertFalse($this->policy->check('list_shares')['allowed']);
+        self::assertFalse($this->policy->check('server_status')['allowed']);
     }
 
     public function testTaskProcessingSurfaceRestrictsMutatingTools(): void {


### PR DESCRIPTION
## Summary

This PR is the next focused security and privacy batch from the issue backlog. It contains no new product feature and does not merge automatically.

## Fixed issues

- Closes #95: block sensitive profile, existing-share listing and server-status tools on the Talk surface while keeping harmless read-only tools available.
- Closes #100: redact link-share capability tokens from all tool output and suppress existing public URLs; a URL is returned only for the newly created link result.
- Closes #103: remove automatic discovery of every Talk room. TaskProcessing only uses explicitly supplied room IDs and caps context at three rooms and the latest 20 messages per room.

## Tests and verification

- PHPUnit: 55 tests, 773 assertions, 6 expected skips
- Targeted regression contracts for #100 and #103 are active and passing
- Talk surface policy regression tests pass
- PHP syntax checks pass
- git diff --check passes
- No frontend source changed; the existing CI frontend build will verify the repository bundle

## Documentation

Updated README.md, TOOLS.md, docs/SECURITY.md and CHANGELOG.md with the new Talk privacy boundaries and share-output redaction behaviour.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>