### PR TITLE
Fix bounded content search and knowledge retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issue #70:** `search_files` now searches bounded readable text content as well as names, returns short content snippets, reports when traversal/result limits were reached, and skips binary or oversized files without aborting the search.
+- **Issue #93:** Knowledge-base trimming now removes only the oldest non-profile lines, preserves the automatic first-run identity section, logs the trim, and reports the warning in the tool result.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ always cite the source file path the model took the information from.
   toml, rtf, sql, …), PDF, Office (docx/xlsx/pptx incl. macro/template variants),
   OpenDocument (odt, ods, odp), EPUB and more
 - **Chat tools** (toggleable, risk-classified — see [Security](docs/SECURITY.md)):
-  - **Files**: list, create, rename, delete, read, search, notes, personal knowledge base (`KNOWLEDGE.md`)
+  - **Files**: list, create, rename, delete, read, bounded name/content search with snippets, notes, personal knowledge base (`KNOWLEDGE.md`)
   - **Contacts**: find, create, update, delete (own, shared, group and Circles address books)
   - **Calendar**: list calendars/events, create/update/delete events, reminders, free-slot search
   - **Mail** (if the Mail app is installed): search, list, read, unread count — plus optional indexing of emails into the RAG index
@@ -245,6 +245,10 @@ See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for details.
 The Settings page groups configuration into five areas: **Connection & models**, **Safety & actions**, **Search & answer quality**, **Indexing & scope**, and **Talk & notifications**. Changes are saved explicitly with **Save changes**; **Save & start indexing** saves first and will not start a run if saving fails.
 
 Use **Check connection** to test the configured Ollama server, embedding model, and chat model. The indexing scope is relative to the user's Files root. The maximum file size is shown in MB in the UI and stored internally as bytes. EVA's recommended delete permission is **Only EVA-created files**; choosing **Any file in my Files** should only be done when that risk is understood. The **Chat history** section can permanently delete all saved EVA chats without touching your files or the document index; the chat sidebar refreshes immediately after deletion.
+
+## File search limits
+
+`search_files` searches names and readable text files (up to 1 MB per file), with bounded traversal (2,000 nodes, depth 5 and 50 results). A `truncated` flag tells the model when a larger search was capped; binary and unsupported files are skipped safely.
 
 ## Calendar tools: supported time formats
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -65,14 +65,14 @@ Reads the text content of a file in the user's home (max. 20,000 characters are 
 | `path` | string | yes | Relative path, e.g. `Documents/Notes.md`. |
 
 ### search_files
-Searches the user's entire Nextcloud home for files by name or content keywords.
+Searches the user's entire Nextcloud home for file/folder names and bounded readable text content. The walk is capped at 2,000 nodes and depth 5, returns at most 50 matches, and reads at most 1 MB per text file; the result includes `truncated` when a limit is reached. Binary and unsupported files are skipped.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `query` | string | yes | Keyword to look for in file and folder names (case-insensitive). |
+| `query` | string | yes | Keyword to look for in file/folder names and bounded readable text content (case-insensitive). |
 
 ### update_knowledge
-Appends personal facts about the user to the knowledge file `KNOWLEDGE.md` in the home folder (e.g. name, family, work, preferences, allergies, plans). Eva calls it whenever the user shares such information explicitly. The file is read before every answer, so the fact is considered in all future chats. Facts are appended as one bullet per entry; old entries are never overwritten.
+Appends personal facts about the user to the knowledge file `KNOWLEDGE.md` in the home folder (e.g. name, family, work, preferences, allergies, plans). Eva calls it whenever the user shares such information explicitly. The file is read before every answer, so the fact is considered in all future chats. Facts are appended as one bullet per entry; when the size limit is reached, only old non-profile lines are trimmed and the automatic identity section is preserved.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ lib/
 | `Ollama` | Thin HTTP client for the Ollama API (embedding + chat) |
 | `Searcher` | Hybrid retrieval: vector search + BM25, fused with RRF |
 | `RagService` | Orchestrates retrieval + prompt building + answer generation |
-| `ActionExecutor` | **Single chokepoint** for all tools — enforces `ToolPolicy` before executing |
+| `ActionExecutor` | **Single chokepoint** for all tools — enforces `ToolPolicy` before executing; bounded name/content file search and protected knowledge trimming |
 | `ToolPolicy` | Central tool registry: risk class, allowed surfaces, confirmation flags |
 | `CalendarService` | CalDAV access: calendars, events, reminders, free slots |
 | `SharesService` | File sharing: list/create/update/delete shares |
@@ -157,6 +157,8 @@ tools are allowed in each:
 ## Current UI and tool boundaries
 
 The workspace uses one responsive `--eva-content-width` token: it expands to `clamp(1180px, 78vw, 1680px)` on large displays and is constrained by the viewport on smaller screens. The native New chat action uses a block-level full width with Nextcloud's native wide modifier, matching the padded Documents and Settings navigation-item width directly below the chat search. Assistant providers keep stable IDs while using the display names `Eva · Local`, `Eva · RAG`, `Eva · Tools`, and `Eva · Agent`.
+
+`search_files` performs a bounded VFS walk and searches names plus readable text-file content, returning snippets and a `truncated` flag when its node/depth/result limits are reached. `update_knowledge` protects the automatic profile block while trimming only old non-profile lines when the file exceeds its size limit.
 
 The centralized tool policy exposes registered read-only tools to the safe RAG/TaskProcessing surfaces. File, calendar, contact, share, and task mutations remain restricted to interactive surfaces and require explicit confirmation where configured. Live web search is not implemented yet; see GitHub issue #54.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,7 +32,7 @@ Every tool is registered centrally with three properties:
 ### Risk classification
 
 - **readonly** — no side effects. Safe on every surface:
-  `list_files`, `read_file`, `search_files`, `find_contact`, `read_profile`,
+  `list_files`, `read_file`, `search_files` (bounded name/content search), `find_contact`, `read_profile`,
   `list_calendars`, `list_calendar_events`, `find_free_slots`, `search_mails`,
   `list_mails`, `read_mail`, `unread_mail_count`, `list_shares`, `list_tasks`,
   `recent_activity`, `server_status`, `current_time`, `weather`.
@@ -91,6 +91,12 @@ For mutating/destructive tools EVA uses a two-phase flow:
 - **`actions_enabled = 0`**: turns the chat into read-only mode — no tools at all.
 - **Scope & exclusions**: `scope_path` and `exclude_paths` limit which folders
   are indexed (and thus visible to the model).
+- **Bounded file search**: `search_files` reads only supported text files up to
+  1 MB each, caps the walk at 2,000 nodes/depth 5/50 results, and never reads
+  binary content. Returned snippets are untrusted file data, not instructions.
+- **Knowledge retention**: when `KNOWLEDGE.md` reaches its size limit, only
+  old non-profile lines are removed; the automatic identity section is retained,
+  and the operation is logged and reported to the user.
 - **TLS verification** for weather and external HTTP calls is enabled; unknown
   certificates are rejected.
 - **Per-user data isolation**: documents, chunks and chat history are bound to

--- a/lib/Service/ActionExecutor.php
+++ b/lib/Service/ActionExecutor.php
@@ -25,10 +25,16 @@ use OCP\Server;
  */
 class ActionExecutor {
     private const MAX_SEARCH_DEPTH = 5;
+    private const MAX_SEARCH_NODES = 2000;
+    private const MAX_SEARCH_FILE_BYTES = 1048576; // 1 MB per text file
+    private const MAX_SEARCH_RESULTS = 50;
     private const MAX_LIST_DEPTH = 2;
     private const MAX_LIST_ENTRIES = 300;
     private const MAX_READ_CHARS = 20000;
     private const MAX_WRITE_CHARS = 100000;
+    private const KNOWLEDGE_MAX_CHARS = 60000;
+    private const KNOWLEDGE_TARGET_CHARS = 45000;
+    private const KNOWLEDGE_PROFILE_MARKER = '<!-- eva_ai:profile-initialized -->';
     private const NOTES_FOLDER = 'Notes';
 
     public function __construct(
@@ -118,7 +124,7 @@ class ActionExecutor {
                 'name' => 'search_files',
                 'description' => 'Search the user\'s entire Nextcloud home for files by name or content keywords.',
                 'parameters' => ['type' => 'object', 'properties' => [
-                    'query' => ['type' => 'string', 'description' => 'Keyword to look for in file and folder names (case-insensitive).'],
+                    'query' => ['type' => 'string', 'description' => 'Keyword to look for in file and folder names and in bounded text-file content (case-insensitive).'],
                 ], 'required' => ['query']],
             ]],
             ['type' => 'function', 'function' => [
@@ -653,31 +659,105 @@ class ActionExecutor {
 
     /** @return array{ok:true,result:array} */
     private function searchFiles(Folder $home, array $args): array {
-        $query = mb_strtolower(trim((string)($args['query'] ?? '')));
+        $query = trim((string)($args['query'] ?? ''));
         if ($query === '') {
             return ['ok' => false, 'error' => 'Search query required'];
         }
         $matches = [];
-        $this->searchWalk($home, $query, $matches, 0, '');
-        return ['ok' => true, 'result' => ['matches' => $matches]];
+        $visited = 0;
+        $truncated = false;
+        $this->searchWalk($home, mb_strtolower($query), $matches, $visited, $truncated, 0, '');
+        return ['ok' => true, 'result' => [
+            'query' => $query,
+            'matches' => $matches,
+            'truncated' => $truncated,
+            'limits' => [
+                'max_results' => self::MAX_SEARCH_RESULTS,
+                'max_nodes' => self::MAX_SEARCH_NODES,
+                'max_depth' => self::MAX_SEARCH_DEPTH,
+                'max_text_file_bytes' => self::MAX_SEARCH_FILE_BYTES,
+            ],
+        ]];
     }
 
-    private function searchWalk(Folder $folder, string $query, array &$matches, int $depth, string $prefix): void {
-        if ($depth >= self::MAX_SEARCH_DEPTH || count($matches) >= 50) {
+    /**
+     * Search names and bounded text content while protecting the request from
+     * an unbounded VFS walk or unexpectedly large/binary files.
+     *
+     * @param array<int,array<string,mixed>> $matches
+     */
+    private function searchWalk(Folder $folder, string $query, array &$matches, int &$visited, bool &$truncated, int $depth, string $prefix): void {
+        if ($depth >= self::MAX_SEARCH_DEPTH || count($matches) >= self::MAX_SEARCH_RESULTS) {
+            $truncated = true;
             return;
         }
         foreach ($folder->getDirectoryListing() as $node) {
-            if (count($matches) >= 50) {
+            if (count($matches) >= self::MAX_SEARCH_RESULTS || $visited >= self::MAX_SEARCH_NODES) {
+                $truncated = true;
                 return;
             }
+            $visited++;
             $rel = $prefix === '' ? $node->getName() : $prefix . '/' . $node->getName();
+            $nameMatches = str_contains(mb_strtolower($node->getName()), $query);
             if ($node instanceof Folder) {
-                $this->searchWalk($node, $query, $matches, $depth + 1, $rel);
+                if ($nameMatches) {
+                    $matches[] = ['path' => $rel, 'reason' => 'filename'];
+                }
+                $this->searchWalk($node, $query, $matches, $visited, $truncated, $depth + 1, $rel);
+                continue;
             }
-            if (str_contains(mb_strtolower($node->getName()), $query)) {
+
+            $contentMatch = null;
+            if ($node instanceof File && $this->isSearchableTextFile($node)) {
+                try {
+                    $content = (string)$node->getContent();
+                    if (strpos($content, "\0") === false) {
+                        $position = mb_stripos($content, $query);
+                        if ($position !== false) {
+                            $contentMatch = $this->searchSnippet($content, $position, mb_strlen($query));
+                        }
+                    }
+                } catch (\Throwable $e) {
+                    // A single unreadable file must not abort the complete search.
+                }
+            }
+
+            if ($nameMatches && $contentMatch !== null) {
+                $matches[] = ['path' => $rel, 'reason' => 'filename and content', 'snippet' => $contentMatch];
+            } elseif ($nameMatches) {
                 $matches[] = ['path' => $rel, 'reason' => 'filename'];
+            } elseif ($contentMatch !== null) {
+                $matches[] = ['path' => $rel, 'reason' => 'content', 'snippet' => $contentMatch];
             }
         }
+    }
+
+    private function isSearchableTextFile(File $file): bool {
+        if ($file->getSize() > self::MAX_SEARCH_FILE_BYTES) {
+            return false;
+        }
+        $mime = strtolower((string)$file->getMimeType());
+        if (str_starts_with($mime, 'text/')) {
+            return true;
+        }
+        return in_array($mime, [
+            'application/json', 'application/ld+json', 'application/xml',
+            'application/x-yaml', 'application/yaml', 'application/rtf',
+            'application/sql', 'application/x-sh', 'application/x-httpd-php',
+        ], true);
+    }
+
+    private function searchSnippet(string $content, int $position, int $queryLength): string {
+        $start = max(0, $position - 120);
+        $snippet = mb_substr($content, $start, $queryLength + 240);
+        $snippet = preg_replace('/\s+/u', ' ', trim($snippet)) ?? trim($snippet);
+        if ($start > 0) {
+            $snippet = '…' . $snippet;
+        }
+        if ($start + mb_strlen($snippet) < mb_strlen($content)) {
+            $snippet .= '…';
+        }
+        return mb_substr($snippet, 0, 300);
     }
 
     /** @return array{ok:true,result:array} */
@@ -774,25 +854,76 @@ class ActionExecutor {
         $content = rtrim($content) . "
 " . $line . "
 ";
-        $newLen = mb_strlen($content);
-        if ($newLen > 60000) {
-            $overflow = $content;
-            while (mb_strlen($overflow) > 45000) {
-                $nl = strpos($overflow, "
-");
-                if ($nl === false) {
-                    break;
-                }
-                $overflow = substr($overflow, $nl + 1);
-            }
-            $content = $overflow;
+        $trimmed = false;
+        if (mb_strlen($content) > self::KNOWLEDGE_MAX_CHARS) {
+            [$content, $trimmed] = $this->trimKnowledge($content);
         }
         if ($home->nodeExists($path)) {
             $home->get($path)->putContent($content);
         } else {
             $home->newFile($path, $content);
         }
-        return ['ok' => true, 'result' => 'Knowledge updated: ' . $line];
+        if ($trimmed) {
+            try {
+                \OC::$server->get(\Psr\Log\LoggerInterface::class)->warning('eva_ai: knowledge file trimmed; automatic profile section preserved', [
+                    'file' => $path,
+                ]);
+            } catch (\Throwable $e) {
+                // Logging must not make a successful knowledge update fail.
+            }
+        }
+        $result = 'Knowledge updated: ' . $line;
+        if ($trimmed) {
+            $result .= ' Older non-profile entries were trimmed to keep KNOWLEDGE.md bounded; the automatic profile section was preserved.';
+        }
+        return ['ok' => true, 'result' => $result];
+    }
+
+    /**
+     * Remove the oldest non-profile lines while retaining the automatic
+     * identity block. The block is recognized by its marker (or heading for
+     * files created before the marker was introduced).
+     *
+     * @return array{0:string,1:bool}
+     */
+    private function trimKnowledge(string $content): array {
+        $lines = explode("\n", $content);
+        $protected = array_fill(0, count($lines), false);
+        $inProfile = false;
+        foreach ($lines as $i => $line) {
+            $trimmed = trim($line);
+            if ($trimmed === self::KNOWLEDGE_PROFILE_MARKER || $trimmed === '## About me (from my Nextcloud profile)') {
+                $inProfile = true;
+            }
+            if ($inProfile) {
+                $protected[$i] = true;
+            }
+            if ($inProfile && str_starts_with($trimmed, '- Imported automatically on ')) {
+                $inProfile = false;
+            }
+        }
+
+        $removed = array_fill(0, count($lines), false);
+        $length = mb_strlen($content);
+        foreach ($lines as $i => $line) {
+            if ($length <= self::KNOWLEDGE_TARGET_CHARS) {
+                break;
+            }
+            if ($protected[$i]) {
+                continue;
+            }
+            $removed[$i] = true;
+            $length -= mb_strlen($line) + ($i < count($lines) - 1 ? 1 : 0);
+        }
+
+        $kept = [];
+        foreach ($lines as $i => $line) {
+            if (!$removed[$i]) {
+                $kept[] = $line;
+            }
+        }
+        $updated = implode("\n", $kept);
+        return [$updated, $updated !== $content];
     }
 
     /** @return array{ok:true,result:array}|array{ok:false,error:string} */

--- a/lib/Service/ToolPolicy.php
+++ b/lib/Service/ToolPolicy.php
@@ -49,7 +49,7 @@ class ToolPolicy {
             'risk' => self::RISK_READONLY,
             'surfaces' => [self::SURFACE_WEB, self::SURFACE_TALK, self::SURFACE_TASKPROCESSING, self::SURFACE_RAG],
             'requiresConfirmation' => false,
-            'description' => 'Search files by name',
+            'description' => 'Search files by name and bounded text content',
         ],
         'create_file' => [
             'risk' => self::RISK_MUTATING,

--- a/tests/OpenIssuesPendingContractTest.php
+++ b/tests/OpenIssuesPendingContractTest.php
@@ -9,6 +9,8 @@ use OCA\EvaAi\Service\AppConfig;
 use OCA\EvaAi\Service\Ollama;
 use OCA\EvaAi\Service\SharesService;
 use OCA\EvaAi\TaskProcessing\TextToTextChatWithToolsProvider;
+use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\IL10N;
@@ -18,11 +20,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Pending regression contracts for the open GitHub issues #99–#106.
+ * Pending regression contracts for the open GitHub issues #99–#106,
+ * plus implemented contracts for #70 and #93.
  *
- * Each test asserts the contract that the FIX must guarantee. The tests are
- * marked `markTestSkipped()` until the corresponding issue is implemented, so
- * CI stays green while the intended behaviour is documented and executable.
+ * Each pending test asserts the contract that its FIX must guarantee and is
+ * skipped until that issue is implemented. The #70 and #93 tests are active
+ * regression tests for the fixes in this branch.
  *
  * When you fix an issue:
  *   1. remove the `markTestSkipped(...)` line of that test,
@@ -37,8 +40,67 @@ final class OpenIssuesPendingContractTest extends TestCase {
 		}
 	}
 
-	/**
-	 * Issue #99: recurring events (RRULE) must be expanded in
+    /**
+     * Issue #70: search_files must search bounded readable content as well as
+     * filenames and report when its traversal limits are reached.
+     */
+    public function testIssue70SearchFilesSearchesBoundedTextContent(): void {
+        $reflection = new \ReflectionClass(ActionExecutor::class);
+        $instance = $reflection->newInstanceWithoutConstructor();
+        $search = $reflection->getMethod('searchFiles');
+        $search->setAccessible(true);
+        $file = $this->createMock(File::class);
+        $file->method('getName')->willReturn('notes.txt');
+        $file->method('getSize')->willReturn(128);
+        $file->method('getMimeType')->willReturn('text/plain');
+        $file->method('getContent')->willReturn('The 2026 budget is approved.');
+        $folder = $this->createMock(Folder::class);
+        $folder->method('getDirectoryListing')->willReturn([$file]);
+        $result = $search->invoke($instance, $folder, ['query' => 'budget']);
+        self::assertSame('content', $result['result']['matches'][0]['reason']);
+        self::assertStringContainsString('budget', $result['result']['matches'][0]['snippet']);
+        self::assertFalse($result['result']['truncated']);
+
+        $executor = (string)file_get_contents(__DIR__ . '/../lib/Service/ActionExecutor.php');
+        self::assertStringContainsString("'reason' => 'content'", $executor);
+        self::assertStringContainsString('getContent()', $this->sliceBetween($executor, 'private function searchWalk', 'private function findContact'));
+        self::assertStringContainsString('MAX_SEARCH_NODES', $executor);
+        self::assertStringContainsString("'truncated' => \$truncated", $executor);
+        self::assertStringContainsString('MAX_SEARCH_FILE_BYTES', $executor);
+    }
+
+    /**
+     * Issue #93: knowledge trimming must preserve the automatic identity block
+     * while dropping old non-profile lines.
+     */
+    public function testIssue93KnowledgeTrimPreservesIdentityBlock(): void {
+        $executor = new \ReflectionClass(ActionExecutor::class);
+        $instance = $executor->newInstanceWithoutConstructor();
+        $method = $executor->getMethod('trimKnowledge');
+        $method->setAccessible(true);
+        $content = implode("\n", [
+            '# Old notes',
+            str_repeat('old fact ', 8000),
+            '<!-- eva_ai:profile-initialized -->',
+            '## About me (from my Nextcloud profile)',
+            '- Nextcloud user ID: alice',
+            '- Name: Alice Example',
+            '- Imported automatically on 2026-08-21.',
+            '- 2026-08-21: newest fact',
+        ]);
+        [$trimmed, $wasTrimmed] = $method->invoke($instance, $content);
+        self::assertTrue($wasTrimmed);
+        self::assertLessThanOrEqual(45000, mb_strlen($trimmed));
+        self::assertStringContainsString('eva_ai:profile-initialized', $trimmed);
+        self::assertStringContainsString('Nextcloud user ID: alice', $trimmed);
+        self::assertStringContainsString('Name: Alice Example', $trimmed);
+        self::assertStringContainsString('newest fact', $trimmed);
+        self::assertStringNotContainsString('# Old notes', $trimmed);
+    }
+
+    /**
+     * Issue #99: recurring events (RRULE) must be expanded in
+
 	 * list_calendar_events and find_free_slots.
 	 */
 	public function testIssue99RecurringEventsAreExpanded(): void {


### PR DESCRIPTION
## Summary

This PR fixes two independent RAG/tool reliability issues without changing the existing web-search or document-format feature scope.

## Fixes

- Closes #70
  - `search_files` now searches file and folder names plus readable text-file content.
  - Content matches include a short snippet and are labelled separately from filename matches.
  - The VFS walk is bounded to 2,000 nodes, depth 5, 50 results, and 1 MB per text file.
  - Binary, unsupported, oversized, and individually unreadable files are skipped safely.
  - The result exposes `truncated` and the active limits so the assistant does not mistake a capped search for a complete negative result.
  - Tool policy and tool documentation now describe the actual behaviour.

- Closes #93
  - `KNOWLEDGE.md` trimming removes only the oldest non-profile lines.
  - The automatic first-run identity section is preserved using its marker (with a heading fallback for older files).
  - A trim is logged when the Nextcloud logger is available and the tool result reports that older entries were removed.

## Documentation and tests

- Updated `README.md`, `TOOLS.md`, `docs/ARCHITECTURE.md`, `docs/SECURITY.md`, and `CHANGELOG.md`.
- Added active regression coverage for content matching, search bounds, profile preservation, and size reduction.

## Verification

- PHPUnit: 57 tests, 817 assertions, 8 expected skips
- PHP syntax checks: passed
- Frontend build: passed (existing optional `stream` Webpack warning only)
- `git diff --check`: passed

## Scope

This PR does not modify PRs #120–#125 or implement feature requests such as web search, OCR, or additional document formats.