### PR TITLE
Fix calendar timezone output and uncapped share lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issues #101 and #106:** calendar event timestamps returned by `list_calendar_events` are now converted to UTC before the `Z` suffix is emitted, and share updates/deletes resolve the provider-aware share ID directly instead of scanning only the first 500 shares of each type.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ always cite the source file path the model took the information from.
   - **Contacts**: find, create, update, delete (own, shared, group and Circles address books)
   - **Calendar**: list calendars/events, create/update/delete events, reminders, free-slot search
   - **Mail** (if the Mail app is installed): search, list, read, unread count — plus optional indexing of emails into the RAG index
-  - **Shares**: list (outgoing + incoming), create link/user/group shares with password, expiry and note; update and delete
+  - **Shares**: list (outgoing + incoming), create link/user/group shares with password, expiry and note; update and delete by stable share ID, including shares beyond the first 500 entries
   - **Tasks**: list, create, update, complete, delete (VTODO, all task-capable calendars)
   - **Profile**: read and update the own Nextcloud profile
   - **Utility**: activity feed, server status, current time (user timezone), weather (Open-Meteo)
@@ -248,7 +248,7 @@ Use **Check connection** to test the configured Ollama server, embedding model, 
 
 ## Calendar tools: supported time formats
 
-The chat interprets times in the user's timezone (e.g. `Europe/Berlin`):
+The chat interprets input times in the user's timezone (e.g. `Europe/Berlin`) and returns timed calendar events as explicit UTC timestamps:
 
 - ISO with/without `Z`: `2026-08-20T16:00:00Z`, `2026-08-20 16:00` (a `Z` is read as local time for non-UTC zones)
 - German formats: `20.08.2026 16:00`, `20/08/2026 16:00`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ lib/
 | `ActionExecutor` | **Single chokepoint** for all tools — enforces `ToolPolicy` before executing |
 | `ToolPolicy` | Central tool registry: risk class, allowed surfaces, confirmation flags |
 | `CalendarService` | CalDAV access: calendars, events, reminders, free slots |
-| `SharesService` | File sharing: list/create/update/delete shares |
+| `SharesService` | File sharing: list/create/update/delete shares; provider-aware direct lookup avoids a 500-entry scan cap |
 | `EmailService` | Mail app integration: search/list/read mails + email indexing |
 | `FileContextChatService` | Chat strictly over selected files (Files app context menu) |
 | `ChatStore` | Chat history persistence in Nextcloud AppData (`eva_ai/chats/<user namespace>/chats.json`) |
@@ -146,6 +146,8 @@ tools are allowed in each:
 - `POST /api/fileContextChat`, `/api/fileContextStatus` — file-context chat
 - `POST /api/check` — connectivity check
 - `GET  /api/models` — available Ollama models
+
+Calendar tool output normalizes timed event timestamps to UTC before adding the `Z` suffix; all-day events remain date-only. Share mutations resolve a provider-aware share ID through Nextcloud's share manager and verify that the authenticated user owns the outgoing share.
 
 ## Testing
 

--- a/lib/Service/CalendarService.php
+++ b/lib/Service/CalendarService.php
@@ -346,8 +346,8 @@ class CalendarService {
                         'id' => $c['uri'] . '/' . $obj['uri'],
                         'calendar' => (string)$c['displayname'],
                         'title' => (string)($ve->SUMMARY ?? ''),
-                        'start' => $dtstart->format('Y-m-d\TH:i:s') . ($isAllDay ? '' : 'Z'),
-                        'end' => $dtend ? $dtend->format('Y-m-d\TH:i:s') . ($isAllDay ? '' : 'Z') : null,
+                        'start' => $this->formatEventDateTime($dtstart, $isAllDay),
+                        'end' => $dtend ? $this->formatEventDateTime($dtend, $isAllDay) : null,
                         'all_day' => $isAllDay,
                         'location' => (string)($ve->LOCATION ?? ''),
                         'description' => (string)($ve->DESCRIPTION ?? ''),
@@ -358,6 +358,18 @@ class CalendarService {
         }
         usort($events, static fn($a, $b) => strcmp((string)$a['start'], (string)$b['start']));
         return ['ok' => true, 'result' => ['events' => $events]];
+    }
+
+    /**
+     * Serialize a parsed calendar date without claiming that a local wall
+     * clock value is UTC. Timed values are converted to UTC before the Z
+     * suffix is emitted; all-day values intentionally remain date-only.
+     */
+    private function formatEventDateTime(\DateTimeInterface $date, bool $allDay): string {
+        if ($allDay) {
+            return $date->format('Y-m-d');
+        }
+        return $date->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\\TH:i:s\\Z');
     }
 
     /** @return array{ok:true,result:array}|array{ok:false,error:string} */

--- a/lib/Service/SharesService.php
+++ b/lib/Service/SharesService.php
@@ -7,7 +7,6 @@ namespace OCA\EvaAi\Service;
 use OCP\Files\IRootFolder;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\IShare;
-use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Constants;
 
 /**
@@ -262,19 +261,32 @@ class SharesService {
         };
     }
 
-    /** Resolve share id ("ocinternal:12", "ocRoomShare:3" or plain id) owned by the user. */
+    /**
+     * Resolve an outgoing share by its stable full ID instead of scanning a
+     * bounded page of shares. Plain IDs are the internal provider IDs emitted
+     * by describe(); prefixed IDs are accepted for compatibility with callers
+     * that already have an IShare full ID.
+     */
     private function findOwnShare(string $userId, string $id): ?IShare {
-        foreach ([IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_LINK] as $type) {
+        $id = trim($id);
+        if ($id === '') {
+            return null;
+        }
+
+        $candidateIds = str_contains($id, ':')
+            ? [$id]
+            : ['ocinternal:' . $id, 'ocCircleShare:' . $id, 'ocMailShare:' . $id, 'ocRoomShare:' . $id, 'deck:' . $id];
+        foreach (array_values(array_unique($candidateIds)) as $candidateId) {
             try {
-                $shares = $this->shareManager->getSharesBy($userId, $type, null, true, 500, 0);
+                $share = $this->shareManager->getShareById($candidateId, $userId);
             } catch (\Throwable $e) {
                 continue;
             }
-            foreach ($shares as $share) {
-                if ((string)$share->getId() === $id
-                    || (str_starts_with((string)$share->getFullId(), 'oc:') && substr((string)$share->getFullId(), 3) === $id)) {
-                    return $share;
-                }
+            // getShareById() enforces recipient visibility, but not ownership.
+            // Keep the original outgoing-share boundary before allowing update
+            // or delete, including for a valid incoming share ID.
+            if ((string)$share->getSharedBy() === $userId) {
+                return $share;
             }
         }
         return null;

--- a/tests/OpenIssuesPendingContractTest.php
+++ b/tests/OpenIssuesPendingContractTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\EvaAi\Tests;
 
 use OCA\EvaAi\Service\ActionExecutor;
+use OCA\EvaAi\Service\CalendarService;
 use OCA\EvaAi\Service\AppConfig;
 use OCA\EvaAi\Service\Ollama;
 use OCA\EvaAi\Service\SharesService;
@@ -93,14 +94,21 @@ final class OpenIssuesPendingContractTest extends TestCase {
 	 * with a correct offset) instead of appending a bare "Z" to local times.
 	 */
 	public function testIssue101EventTimesAreReportedInUtc(): void {
-		$this->markTestSkipped('Fix for issue #101 (UTC conversion in listEvents) is not implemented yet');
 		$calendar = (string)file_get_contents(__DIR__ . '/../lib/Service/CalendarService.php');
 		$slice = $this->sliceBetween($calendar, 'public function listEvents', 'public function createEvent');
 		self::assertStringContainsString(
-			"setTimezone(new \\DateTimeZone('UTC'))",
+			'formatEventDateTime',
 			$slice,
-			'list_calendar_events must convert event times to UTC before appending "Z"'
+			'list_calendar_events must use the timezone-safe serializer'
 		);
+
+		$reflection = new \ReflectionClass(CalendarService::class);
+		$instance = $reflection->newInstanceWithoutConstructor();
+		$method = $reflection->getMethod('formatEventDateTime');
+		$method->setAccessible(true);
+		$local = new \DateTimeImmutable('2026-08-20 16:00:00', new \DateTimeZone('Europe/Berlin'));
+		self::assertSame('2026-08-20T14:00:00Z', $method->invoke($instance, $local, false));
+		self::assertSame('2026-08-20', $method->invoke($instance, $local, true));
 	}
 
 	/**
@@ -194,12 +202,22 @@ final class OpenIssuesPendingContractTest extends TestCase {
 	 * first 500 per type can be updated and deleted.
 	 */
 	public function testIssue106ShareLookupUsesIdFirst(): void {
-		$this->markTestSkipped('Fix for issue #106 (share id lookup) is not implemented yet');
 		$shares = (string)file_get_contents(__DIR__ . '/../lib/Service/SharesService.php');
+		$slice = $this->sliceToEnd($shares, 'private function findOwnShare');
 		self::assertStringContainsString(
 			'getShareById',
-			$shares,
+			$slice,
 			'findOwnShare must resolve shares by id before iterating'
+		);
+		self::assertStringContainsString(
+			'\'ocinternal:\' . $id',
+			$slice,
+			'plain provider IDs must be resolved through the internal share provider'
+		);
+		self::assertStringNotContainsString(
+			'getSharesBy($userId, $type, null, true, 500, 0)',
+			$slice,
+			'findOwnShare must not be limited to the first 500 shares'
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes two independent calendar/share reliability issues without changing the existing web-search, document-format, indexing, or UI feature scope.

## Fixes

- Closes #101
  - Timed `list_calendar_events` values are converted to UTC before the `Z` suffix is emitted.
  - All-day events remain date-only and are not accidentally shifted by timezone conversion.
  - The serializer is covered for a Europe/Berlin input and an all-day value.

- Closes #106
  - Share update/delete now resolve provider-aware IDs through Nextcloud's `getShareById()` API.
  - Plain internal IDs and prefixed full IDs remain supported.
  - The authenticated user must still be the outgoing share initiator.
  - The old first-500-per-type scan is removed, so shares beyond that page can be managed.

## Documentation and tests

- Updated `README.md`, `docs/ARCHITECTURE.md`, and `CHANGELOG.md`.
- Activated and strengthened the regression contracts for #101 and #106.

## Verification

- PHPUnit: 55 tests, 808 assertions, 6 expected skips
- Targeted #101/#106 contracts: passed
- PHP syntax checks: passed
- Frontend production build: passed; existing optional `stream` Webpack warning only
- `git diff --check`: passed
- Working tree: clean

## Scope

This PR is based on `origin/main` and does not modify PRs #120–#126 or implement feature requests such as web search, OCR, recurring-event expansion, or additional document formats.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>