### PR TITLE
Continue large indexing jobs across queue runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issue #110:** large queued indexing jobs now enqueue a continuation after the bounded pass budget instead of stopping with a misleading safety-limit error.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ tools always require explicit user confirmation. See [docs/SECURITY.md](docs/SEC
 
 ## Development
 
+Queued indexing runs are bounded per worker execution and enqueue a continuation when the pass budget is reached. This allows very large libraries to finish without monopolising a single background worker.
+
 - **Tests**: `composer test` (PHPUnit) — security, provider, settings and migration regressions
 - **Frontend build**: `npm ci && npm run build`; CI also verifies that the expected generated bundles are emitted
 - **CI**: GitHub Actions on PHP 8.2 / 8.3 / 8.4 (see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)), dependency security audits (`quality.yml`) and nightly Nextcloud compatibility checks across all supported release lines (`nightly.yml`)

--- a/lib/BackgroundJob/IndexRequestJob.php
+++ b/lib/BackgroundJob/IndexRequestJob.php
@@ -7,6 +7,7 @@ namespace OCA\EvaAi\BackgroundJob;
 use OCA\EvaAi\Service\AppConfig;
 use OCA\EvaAi\Service\Indexer;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\QueuedJob;
 use Psr\Log\LoggerInterface;
 
@@ -16,13 +17,17 @@ use Psr\Log\LoggerInterface;
  * configured scope is up to date or the user requests cancellation.
  */
 class IndexRequestJob extends QueuedJob {
+    // Keep one queue execution bounded. A follow-up job is queued when the
+    // pass budget is exhausted, so very large libraries can make progress
+    // without monopolising a worker indefinitely.
     private const MAX_PASSES = 1000;
 
     public function __construct(
         ITimeFactory $time,
         private AppConfig $config,
         private Indexer $indexer,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
+        private IJobList $jobList
     ) {
         parent::__construct($time);
     }
@@ -66,9 +71,18 @@ class IndexRequestJob extends QueuedJob {
                 }
             } while ($passes < self::MAX_PASSES);
 
-            if ($passes >= self::MAX_PASSES) {
-                $this->config->set('last_index_error', 'Indexing stopped after the safety pass limit.');
-                $this->logger->warning('eva_ai: background index pass limit reached', [
+            if ($passes >= self::MAX_PASSES && !$this->cancelRequested($runId)) {
+                // Do not report a successful continuation as an error. Queue
+                // the same run again; the run id preserves cancellation and
+                // stale-job protection across the hand-off.
+                $this->config->set('index_running', '1');
+                $this->config->set('index_mode', $mode);
+                $this->jobList->add(self::class, [
+                    'userId' => $userId,
+                    'mode' => $mode,
+                    'runId' => $runId,
+                ]);
+                $this->logger->info('eva_ai: queued follow-up index pass batch', [
                     'userId' => $userId,
                     'mode' => $mode,
                 ]);

--- a/tests/OpenIssuesPendingContractTest.php
+++ b/tests/OpenIssuesPendingContractTest.php
@@ -175,6 +175,16 @@ final class OpenIssuesPendingContractTest extends TestCase {
 	}
 
 	/**
+	 * Issue #110: exhausting one worker's pass budget must queue a follow-up
+	 * job instead of reporting a false terminal error.
+	 */
+	public function testIssue110BackgroundIndexQueuesContinuation(): void {
+		$job = (string)file_get_contents(__DIR__ . '/../lib/BackgroundJob/IndexRequestJob.php');
+		self::assertStringContainsString('$this->jobList->add(self::class', $job);
+		self::assertStringNotContainsString('Indexing stopped after the safety pass limit.', $job);
+	}
+
+	/**
 	 * Issue #105: agent state rows must be pruned (TTL / cleanup job) instead
 	 * of growing without bound.
 	 */


### PR DESCRIPTION
## Summary

- Fixes #110 by queueing a follow-up `IndexRequestJob` when the bounded pass budget is exhausted.
- Keeps the existing run ID and cancellation/stale-job safeguards across the queue hand-off.
- Avoids reporting the pass budget as a misleading indexing error.
- Updates the README and changelog and adds a regression contract.

## Verification

- PHPUnit: 56 tests, 801 assertions, 8 skips
- PHP syntax checks: passed
- Frontend build: passed (existing optional `stream` webpack warning only)
- `git diff --check`: passed
