### PR TITLE
Bound legacy configuration migration memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issue #111:** legacy app-ID migration now copies each user's settings during the user-manager callback instead of collecting every UID in memory first.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ tools always require explicit user confirmation. See [docs/SECURITY.md](docs/SEC
 
 ## Development
 
+Legacy configuration migration processes each user immediately during the Nextcloud user-manager traversal, keeping memory usage bounded on large installations.
+
 - **Tests**: `composer test` (PHPUnit) — security, provider, settings and migration regressions
 - **Frontend build**: `npm ci && npm run build`; CI also verifies that the expected generated bundles are emitted
 - **CI**: GitHub Actions on PHP 8.2 / 8.3 / 8.4 (see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)), dependency security audits (`quality.yml`) and nightly Nextcloud compatibility checks across all supported release lines (`nightly.yml`)

--- a/lib/Migration/MigrateLegacyAppIdRepairStep.php
+++ b/lib/Migration/MigrateLegacyAppIdRepairStep.php
@@ -40,25 +40,24 @@ class MigrateLegacyAppIdRepairStep implements IRepairStep {
             }
         }
 
-        $users = [];
-        $this->userManager->callForAllUsers(function ($user) use (&$users): void {
-            $users[] = (string)$user->getUID();
-        });
-        foreach (array_values(array_unique($users)) as $userId) {
+        $userCount = 0;
+        $this->userManager->callForAllUsers(function ($user) use (&$userCount): void {
+            $userId = (string)$user->getUID();
             foreach ($this->config->getUserKeys($userId, self::LEGACY) as $key) {
                 $value = $this->config->getUserValue($userId, self::LEGACY, $key, '');
                 if ($value !== '') {
                     $this->config->setUserValue($userId, self::CURRENT, $key, $value);
                 }
             }
-        }
+            $userCount++;
+        });
 
         // Remove only after every value was copied. This avoids leaving a
         // second active configuration namespace behind after a successful run.
         if ($keys !== []) {
             $this->config->deleteAppValues(self::LEGACY);
         }
-        if ($users !== []) {
+        if ($userCount > 0) {
             $this->config->deleteAppFromAllUsers(self::LEGACY);
         }
         $output->info('Migrated legacy EVA configuration from eva-ai to eva_ai.');

--- a/tests/MigrationRegressionTest.php
+++ b/tests/MigrationRegressionTest.php
@@ -85,6 +85,8 @@ final class MigrationRegressionTest extends TestCase {
         self::assertStringContainsString('MigrateLegacyAppIdRepairStep', $info);
         self::assertStringContainsString('getAppKeys(self::LEGACY)', $repair);
         self::assertStringContainsString('getUserKeys($userId, self::LEGACY)', $repair);
+        self::assertStringNotContainsString('$users = []', $repair);
+        self::assertStringContainsString('$userCount = 0', $repair);
         self::assertStringContainsString('setAppValue(self::CURRENT', $repair);
         self::assertStringContainsString('setUserValue($userId, self::CURRENT', $repair);
     }


### PR DESCRIPTION
## Summary

- Fixes #111 by migrating each user's legacy EVA settings inside the existing user-manager callback.
- Removes the temporary all-user UID array, keeping migration memory bounded on large installations.
- Preserves the existing copy-before-delete and idempotent migration behavior.
- Updates the README and changelog and adds a regression assertion.

## Verification

- PHPUnit: 55 tests, 801 assertions, 8 skips
- Migration regression tests: 4 tests, 22 assertions
- PHP syntax checks: passed
- Frontend production build: passed (existing optional `stream` webpack warning only)
- `git diff --check`: passed
