### PR TITLE
Clean up duplicate legacy migration tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Issue #116:** legacy `ragchat_*` tables are now explicitly removed when their current `eva_ai_*` counterparts already exist after a partial upgrade.
 - **Indexing API**: use native Nextcloud request parameters with a single non-recursive JSON fallback instead of a recursively named input wrapper; duplicate starts now remain idempotent while genuine worker-lock conflicts still return an actionable 409.
 - **Frontend**: the main Vue bundle is now emitted as `eva_ai-main.js` (was
   `eva-ai-main.js`), matching the name the page controller looks up. The app

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ tools always require explicit user confirmation. See [docs/SECURITY.md](docs/SEC
 
 ## Development
 
+The app-ID migration treats the current `eva_ai_*` tables as authoritative and removes duplicate legacy `ragchat_*` tables left by interrupted upgrades.
+
 - **Tests**: `composer test` (PHPUnit) — security, provider, settings and migration regressions
 - **Frontend build**: `npm ci && npm run build`; CI also verifies that the expected generated bundles are emitted
 - **CI**: GitHub Actions on PHP 8.2 / 8.3 / 8.4 (see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)), dependency security audits (`quality.yml`) and nightly Nextcloud compatibility checks across all supported release lines (`nightly.yml`)

--- a/lib/Migration/Version101000Date20260810000000.php
+++ b/lib/Migration/Version101000Date20260810000000.php
@@ -22,9 +22,19 @@ class Version101000Date20260810000000 extends SimpleMigrationStep {
 			'ragchat_chunks'    => 'eva_ai_chunks',
 		];
 		foreach ($renames as $old => $new) {
-			if ($schema->hasTable($old) && !$schema->hasTable($new)) {
-				$schema->renameTable($old, $new);
+			if (!$schema->hasTable($old)) {
+				continue;
 			}
+			if (!$schema->hasTable($new)) {
+				$schema->renameTable($old, $new);
+				continue;
+			}
+
+			// A partial upgrade can leave both names behind. The current table
+			// is authoritative; drop the obsolete duplicate instead of silently
+				// preserving stale indexed data forever.
+			$schema->dropTable($old);
+			$output->warning('Dropped obsolete legacy table ' . $old . ' because ' . $new . ' already exists.');
 		}
 		return $schema;
 	}

--- a/tests/MigrationRegressionTest.php
+++ b/tests/MigrationRegressionTest.php
@@ -20,6 +20,13 @@ final class MigrationRegressionTest extends TestCase {
         }
     }
 
+    public function testLegacyTableMigrationDropsObsoleteDuplicateTables(): void {
+        $source = (string)file_get_contents(__DIR__ . '/../lib/Migration/Version101000Date20260810000000.php');
+        self::assertStringContainsString('$schema->dropTable($old)', $source);
+        self::assertStringContainsString('$schema->hasTable($new)', $source);
+        self::assertStringContainsString('$output->warning', $source);
+    }
+
     public function testIndexRepairKeepsLiteralLegacyNamesAndAvoidsSelfRename(): void {
         $source = (string)file_get_contents(__DIR__ . '/../lib/Migration/Version104000Date20260812000000.php');
 


### PR DESCRIPTION
## Summary

- Fixes #116 by handling hybrid migration states where both `ragchat_*` and `eva_ai_*` tables exist.
- Treats the current `eva_ai_*` table as authoritative and explicitly drops the obsolete legacy table.
- Logs the cleanup through the migration output and keeps the migration idempotent.
- Updates the README and changelog and adds a migration regression contract.

## Verification

- PHPUnit: 56 tests, 802 assertions, 8 skips
- Migration regression tests: 5 tests, 23 assertions
- PHP syntax checks: passed
- Frontend production build: passed (existing optional `stream` webpack warning only)
- `git diff --check`: passed
